### PR TITLE
Align service token contract docs and smoke coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ STATUS.md
 AGENTS.md
 .vscode
 .idea
+.DS_Store
 .codex
 .gemini
 .gemini-cli
@@ -12,4 +13,6 @@ node_modules
 dist
 coverage
 storybook-static
+playwright-report
+test-results
 *.tgz

--- a/README.md
+++ b/README.md
@@ -109,9 +109,14 @@ backend.add(serviceTokenHandlerModule);
 
 ```typescript
 // packages/app/src/App.tsx (new frontend system)
+import { createApp } from '@backstage/frontend-defaults';
 import serviceTokensPlugin from '@adriandantas/plugin-service-tokens';
 
-app.addFeatures([serviceTokensPlugin]);
+const app = createApp({
+  features: [serviceTokensPlugin],
+});
+
+export default app.createRoot();
 ```
 
 ### 4. Add a permission policy
@@ -168,7 +173,7 @@ curl -s "https://your-backstage/api/catalog/entities?limit=10" \
   -H "Authorization: Bearer <rawToken>"
 ```
 
-The token authenticates as the group it was scoped to. Revoked or expired tokens return `401 Unauthorized`.
+The token authenticates as the group it was scoped to. Revoked or expired tokens return `401 Unauthorized` after cache invalidation, bounded by `serviceTokens.cacheTtlSeconds`.
 
 ---
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -209,7 +209,7 @@ curl -s -X POST http://localhost:7007/api/service-tokens \
     "revokedBy": null,
     "status": "active"
   },
-  "rawToken": "bst_v1_a1b2c3d4e5f6..."
+  "rawToken": "bsst_a1b2c3d4e5f6..."
 }
 ```
 
@@ -219,7 +219,7 @@ curl -s -X POST http://localhost:7007/api/service-tokens \
 
 | Status | Body | Cause |
 |---|---|---|
-| `400 Bad Request` | `{"error": "..."}` | Missing required fields, invalid scope IDs, expiry exceeds maximum, or group not found in catalog |
+| `422 Unprocessable Entity` | `{"error": "..."}` | Missing required fields, invalid scope IDs, expiry exceeds maximum, or group not found in catalog |
 | `409 Conflict` | `{"error": "..."}` | A token with the same name already exists for this group |
 
 ---
@@ -247,11 +247,18 @@ curl -s http://localhost:7007/api/service-tokens/3fa85f64-5717-4562-b3fc-2c963f6
 
 ```json
 {
-  "token": {
-    "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-    "name": "ci-pipeline",
-    ...
-  }
+  "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "name": "ci-pipeline",
+  "description": "Token for the main CI pipeline",
+  "groupEntityRef": "group:default/platform",
+  "scopes": ["catalog:read"],
+  "createdBy": "user:default/alice",
+  "createdAt": "2025-01-15T10:30:00.000Z",
+  "expiresAt": "2025-02-14T10:30:00.000Z",
+  "lastUsedAt": null,
+  "revokedAt": null,
+  "revokedBy": null,
+  "status": "active"
 }
 ```
 
@@ -335,18 +342,20 @@ curl -s http://localhost:7007/api/service-tokens/3fa85f64-5717-4562-b3fc-2c963f6
     {
       "id": "a1b2c3d4-...",
       "tokenId": "3fa85f64-...",
-      "action": "created",
-      "performedBy": "user:default/alice",
-      "occurredAt": "2025-01-15T10:30:00.000Z",
-      "reason": null
+      "event": "revoked",
+      "actor": "user:default/alice",
+      "metadata": {
+        "reason": "Rotating credentials"
+      },
+      "occurredAt": "2025-01-20T14:00:00.000Z"
     },
     {
       "id": "e5f6a7b8-...",
       "tokenId": "3fa85f64-...",
-      "action": "revoked",
-      "performedBy": "user:default/alice",
-      "occurredAt": "2025-01-20T14:00:00.000Z",
-      "reason": "Rotating credentials"
+      "event": "created",
+      "actor": "user:default/alice",
+      "metadata": {},
+      "occurredAt": "2025-01-15T10:30:00.000Z"
     }
   ]
 }
@@ -358,12 +367,12 @@ curl -s http://localhost:7007/api/service-tokens/3fa85f64-5717-4562-b3fc-2c963f6
 |---|---|---|
 | `id` | string (UUID) | Unique event identifier |
 | `tokenId` | string (UUID) | The token this event belongs to |
-| `action` | `created` \| `revoked` | The lifecycle action |
-| `performedBy` | string | User entity ref of the actor |
+| `event` | `created` \| `revoked` | The lifecycle event |
+| `actor` | string \| null | User entity ref of the actor |
+| `metadata` | object | Event-specific metadata, such as `{ "reason": "..." }` for revocation |
 | `occurredAt` | ISO 8601 | When the event occurred |
-| `reason` | string \| null | Reason provided at revocation, or `null` |
 
-Events are returned in ascending chronological order.
+Events are returned in descending chronological order (newest first).
 
 ---
 
@@ -374,7 +383,7 @@ Raw service tokens are used as Bearer tokens against any Backstage backend API e
 ```bash
 # Use a service token to call the Catalog API
 curl -s "http://localhost:7007/api/catalog/entities?limit=10" \
-  -H "Authorization: Bearer bst_v1_a1b2c3d4e5f6..."
+  -H "Authorization: Bearer bsst_a1b2c3d4e5f6..."
 ```
 
 **Token behaviour:**

--- a/docs/contract-decisions.md
+++ b/docs/contract-decisions.md
@@ -1,0 +1,60 @@
+# Contract Decisions
+
+This note records the canonical public behavior for the plugin where earlier LLM-assisted sessions left code, tests, and docs out of sync.
+
+These decisions are the source of truth for future edits unless the public contract is intentionally changed.
+
+---
+
+## Audit Log API
+
+- `GET /api/service-tokens/:id/audit` returns an object with an `events` array.
+- Each audit event uses the current backend/storage field names:
+  - `id`
+  - `tokenId`
+  - `event`
+  - `actor`
+  - `metadata`
+  - `occurredAt`
+- Revocation reasons are stored inside `metadata.reason`.
+
+Why:
+
+- This matches the implemented database model and backend tests.
+- It preserves a stable, extensible event envelope for future audit metadata without introducing event-specific top-level fields.
+
+---
+
+## Audit Event Ordering
+
+- Audit events are returned newest-first.
+
+Why:
+
+- This is the most useful operator default in admin UIs and API inspection flows.
+- It matches the existing backend implementation and frontend expectation for recent activity first.
+
+---
+
+## Revocation and Cache TTL
+
+- Revocation takes effect after cache invalidation, which is bounded by `serviceTokens.cacheTtlSeconds`.
+- The documented default remains `60` seconds.
+- Beginner/tutorial flows should explicitly set `serviceTokens.cacheTtlSeconds: 0` when they need deterministic immediate rejection after revocation.
+
+Why:
+
+- Claiming immediate rejection under default settings is misleading.
+- Explicit zero-TTL tutorial config gives a predictable developer experience without changing the production-oriented default.
+
+---
+
+## Frontend Installation Pattern
+
+- The canonical setup example uses `createApp({ features: [...] })` with `serviceTokensPlugin` included in the `features` array.
+- Documentation should show `@backstage/frontend-defaults` as the recommended import for scaffolded Backstage apps unless a document is specifically about another app bootstrap style.
+
+Why:
+
+- This matches the current tutorial path and common Backstage scaffold expectations.
+- One primary example reduces adoption friction and avoids docs drift.

--- a/docs/developer-test-guide.md
+++ b/docs/developer-test-guide.md
@@ -1,0 +1,326 @@
+# Developer Test Guide
+
+This guide is the fastest reliable way to validate the plugin locally **before the packages are published to npm**.
+
+Use it when you are changing the plugin itself and want a maintainer-focused answer to one of these questions:
+
+- Does the plugin still work in a real Backstage app?
+- Do local `file:` installs still behave correctly before publication?
+- Does the admin UI still support the core create → audit → revoke flow?
+
+If you are validating the plugin as an adopter, start with the [Tutorial](tutorial.md). If you want the broad end-to-end operator flow after installation, use the [Testing Guide](testing.md). This guide is for maintainers iterating on unpublished changes.
+
+---
+
+## What This Guide Covers
+
+- Node 22 verification in this repo
+- Local `file:` installs into a Backstage app
+- A fast repeat harness using `my-portal`
+- API smoke coverage with `scripts/test-api.sh`
+- UI smoke coverage with Playwright
+
+The canonical contract for this guide matches:
+
+- [REST API Reference](api.md)
+- [Testing Guide](testing.md)
+- [Contract Decisions](contract-decisions.md)
+
+That means:
+
+- audit responses use `events` with `event`, `actor`, `metadata`, and `occurredAt`
+- audit events are returned newest-first
+- deterministic local revocation checks rely on `serviceTokens.cacheTtlSeconds: 0`
+
+---
+
+## When To Use This Guide
+
+Use this guide instead of the main tutorial when:
+
+- you are validating unpublished package changes
+- you need local `file:` installs instead of npm packages
+- you want a repeatable maintainer loop against `/Users/adrian/src/my-portal`
+- you want both API and UI smoke checks without re-scaffolding a new app every time
+
+Use the tutorial instead when:
+
+- you want the adopter experience from scratch
+- you are checking docs readability for platform engineers
+- you want the simplest end-user install story
+
+---
+
+## Prerequisites
+
+Make sure these are available:
+
+- Node `22`
+- Yarn
+- `jq`
+- `curl`
+- this plugin repo cloned locally
+- the local harness app at `/Users/adrian/src/my-portal`
+
+Check the toolchain:
+
+```bash
+node --version
+yarn --version
+jq --version
+curl --version | head -n 1
+```
+
+If you use `nvm`:
+
+```bash
+source ~/.nvm/nvm.sh
+nvm use 22
+```
+
+Expected:
+
+- `node --version` reports `v22.x`
+- Yarn is available
+- `jq` and `curl` are installed
+
+---
+
+## 1. Verify This Repo First
+
+From this repo:
+
+```bash
+cd /path/to/backstage-service-token-plugin
+npm test
+npm run pack:dry-run
+```
+
+Expected:
+
+- all tests pass
+- all three packages pack successfully in dry-run mode
+
+If this fails, stop and fix the plugin repo before moving on.
+
+---
+
+## 2. Fast Repeat Path — Use `my-portal`
+
+This is the recommended maintainer loop after the first integration is working.
+
+Why:
+
+- it is already aligned to the tutorial contract
+- it uses local `file:` dependencies from this repo
+- it is fast to re-run after plugin changes
+
+Before starting the harness, confirm these behaviors in `/Users/adrian/src/my-portal`:
+
+- `backend.auth.externalAccess` includes `backstage-service-token`
+- `serviceTokens.admin.userEntityRefs` includes `user:development/guest`
+- `serviceTokens.cacheTtlSeconds: 0` is set in local config
+- `group:default/platform` exists in `examples/org.yaml`
+- local `file:` dependencies have been refreshed with `yarn install`
+
+Then start the harness:
+
+```bash
+cd /Users/adrian/src/my-portal
+yarn start
+```
+
+Expected:
+
+- frontend serves on `http://localhost:3000`
+- backend listens on `http://localhost:7007`
+- no startup error occurs for the service token plugin
+
+---
+
+## 3. Run the API Smoke Path
+
+From this repo, with `my-portal` running:
+
+```bash
+cd /path/to/backstage-service-token-plugin
+npm run test:api-script -- http://localhost:7007
+```
+
+Expected:
+
+- guest token acquisition succeeds
+- scope listing succeeds
+- token creation returns `201` and a one-time `rawToken`
+- raw token authenticates against the Catalog API
+- audit log returns an `events` array
+- revoke returns `204`
+- revoked raw token is rejected with `401`
+- unauthenticated create is rejected with `401`
+
+If this fails, treat it as a contract or harness issue first, not a Playwright issue.
+
+---
+
+## 4. Run the Playwright UI Smoke Path
+
+With `my-portal` already running:
+
+```bash
+cd /path/to/backstage-service-token-plugin
+PLAYWRIGHT_BASE_URL=http://localhost:3000 npm run test:ui-smoke
+```
+
+Optional:
+
+```bash
+PLAYWRIGHT_BASE_URL=http://localhost:3000 npm run test:ui-smoke:headed
+```
+
+Expected:
+
+- the service token page loads
+- the create dialog works for a unique token
+- the success dialog shows the raw token once
+- the audit dialog shows `created`
+- revoke succeeds
+- the table shows `Revoked`
+- the audit dialog shows newest-first ordering: `revoked`, then `created`
+
+This smoke test intentionally covers only the primary happy path. It does not yet validate every permission or error branch.
+
+---
+
+## 5. Fresh App Path — Revalidate Local `file:` Installs
+
+Use this path when you want to prove the plugin still works in a newly scaffolded Backstage app before publication.
+
+Create a fresh app:
+
+```bash
+source ~/.nvm/nvm.sh
+nvm use 22
+cd /tmp
+npx @backstage/create-app@latest
+```
+
+Move into the new app:
+
+```bash
+cd /tmp/service-token-dev-test
+```
+
+Reinstall under Node 22:
+
+```bash
+yarn install
+```
+
+Expected:
+
+- the clean app starts before plugin changes
+- Node 22 is the active runtime for native modules
+
+---
+
+## 6. Install the Plugin From Local Package Folders
+
+Use this plugin repo path as an example:
+
+```text
+/path/to/backstage-service-token-plugin
+```
+
+Add a root Yarn resolution before backend install so the local node package is used consistently:
+
+```json
+"resolutions": {
+  "@types/react": "^18",
+  "@types/react-dom": "^18",
+  "@adriandantas/plugin-service-tokens-node@npm:^0.1.0": "file:/path/to/backstage-service-token-plugin/packages/plugin-service-tokens-node"
+}
+```
+
+If `resolutions` already exists, add the service-token entry rather than replacing existing values.
+
+Then run:
+
+```bash
+yarn install
+```
+
+Install the plugin packages with local `file:` paths:
+
+```bash
+yarn --cwd packages/backend add \
+  @adriandantas/plugin-service-tokens-node@file:/path/to/backstage-service-token-plugin/packages/plugin-service-tokens-node
+
+yarn --cwd packages/backend add \
+  @adriandantas/plugin-service-tokens-backend@file:/path/to/backstage-service-token-plugin/packages/plugin-service-tokens-backend
+
+yarn --cwd packages/app add \
+  @adriandantas/plugin-service-tokens@file:/path/to/backstage-service-token-plugin/packages/plugin-service-tokens
+```
+
+Then run:
+
+```bash
+yarn install
+```
+
+Expected:
+
+- installs succeed
+- peer warnings may appear
+- the local packages are materialized into the app successfully
+
+---
+
+## 7. Wire the Fresh App to Match the Tutorial Contract
+
+Use the [Tutorial](tutorial.md) and [Getting Started](getting-started.md) documents as the canonical wiring reference.
+
+For parity, the fresh app should end up with:
+
+- backend plugin registration
+- auth handler registration
+- custom permission policy
+- `backend.auth.externalAccess` for `backstage-service-token`
+- `serviceTokens.admin.userEntityRefs` including `user:development/guest`
+- `serviceTokens.cacheTtlSeconds: 0` in local config
+- `group:default/platform` present in the catalog
+- frontend registration of `serviceTokensPlugin`
+
+Expected:
+
+- `/admin/service-tokens` loads without `401` or `403`
+- API and UI smoke paths behave the same way as the maintainer harness
+
+---
+
+## 8. What To Record If Something Fails
+
+Capture:
+
+- the exact command you ran
+- the exact error output
+- whether the failure was in this repo, `my-portal`, or a fresh app
+- whether the failure was in the API smoke path or the Playwright smoke path
+- whether the failure was contract-related, install-related, or harness-related
+
+That keeps maintainer debugging grounded in facts instead of assumptions.
+
+---
+
+## Recommended Maintainer Loop
+
+For day-to-day iteration:
+
+1. Change the plugin
+2. Run `npm test`
+3. Refresh `my-portal` with `yarn install` if package contents changed
+4. Start `my-portal`
+5. Run `npm run test:api-script -- http://localhost:7007`
+6. Run `PLAYWRIGHT_BASE_URL=http://localhost:3000 npm run test:ui-smoke`
+
+That gives quick confidence in both contract behavior and the main admin UI path before publication work begins.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,7 +12,7 @@ This guide walks a platform engineer through installing and wiring the service t
 
 ## Prerequisites
 
-- A working Backstage app using the **new backend system** (`createBackend`) and the **new frontend system** (`createApp` from `@backstage/frontend-app-api`)
+- A working Backstage app using the **new backend system** (`createBackend`) and the **new frontend system** (`createApp`)
 - Node.js 22
 - The plugin workspace cloned or copied alongside your Backstage monorepo
 
@@ -100,7 +100,7 @@ backend.start();
 
 ```typescript
 // packages/app/src/App.tsx
-import { createApp } from '@backstage/frontend-app-api';
+import { createApp } from '@backstage/frontend-defaults';
 import serviceTokensPlugin from '@adriandantas/plugin-service-tokens';
 
 const app = createApp({

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,8 +17,10 @@ This plugin provides:
 - [Getting Started](getting-started.md) — install and wire the plugin into an existing Backstage app
 - [Configuration Reference](configuration.md) — all `serviceTokens` config keys and defaults
 - [REST API Reference](api.md) — request/response formats for all endpoints
+- [Contract Decisions](contract-decisions.md) — canonical public behavior where earlier sessions diverged
 - [Architecture](architecture.md) — package design, token lifecycle, and database model
 - [Testing Guide](testing.md) — end-to-end API and UI test flows
+- [Developer Test Guide](developer-test-guide.md) — fastest local integration path before npm publication
 - [Release Guide](releasing.md) — versioning and publishing the npm packages
 - [Production Readiness](production-readiness.md) — group-based admin access, policy merging, cache tuning, audit retention
 - [Scope Enforcement Runbook](runbooks/scope-enforcement.md) — optional operator guidance for consumer-driven enforcement

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,8 +1,8 @@
 # Testing the Service Token Plugin
 
-This guide walks through exercising the `backstage-service-token-plugin` end-to-end against the `super-dev-portal` integration harness.
+This guide walks through exercising the `backstage-service-token-plugin` end-to-end against a local Backstage integration harness.
 
-> **Note:** Path examples in this document use `/home/roberto/projects/super-dev-portal` because they were captured from the reference harness. Replace with your own Backstage app path when following these steps.
+> **Maintainer note:** If you are iterating on unpublished plugin changes, use the [Developer Test Guide](developer-test-guide.md) for the fastest repeatable path with `/Users/adrian/src/my-portal`. This guide stays focused on the adopter-style end-to-end flows.
 
 The frontend UI at `/admin/service-tokens` provides a full page experience: token list with filters, a **Create token** button, and **Audit** / **Revoke** actions per row — all wired to the backend. Choose the path that suits your workflow:
 
@@ -14,8 +14,9 @@ The frontend UI at `/admin/service-tokens` provides a full page experience: toke
 |------|---------------|
 | [Path A — API Testing](#path-a--api-testing) | Full end-to-end via `curl` — no browser required |
 | [Path B — UI Testing](#path-b--ui-testing) | Full end-to-end via the browser UI |
+| [Path C — Playwright Smoke](#path-c--playwright-smoke) | Maintainer-oriented create → audit → revoke UI smoke path |
 
-Both paths cover the same scenarios (create, list, audit, revoke, permission enforcement). You can also mix them — e.g. create via the UI and verify via the API.
+Paths A and B cover the same scenarios (create, list, audit, revoke, permission enforcement). Path C is intentionally narrower: it validates the primary admin UI flow against a local harness. You can also mix the paths — for example, create via the UI and verify via the API.
 
 ---
 
@@ -129,7 +130,7 @@ curl -s http://localhost:7007/api/service-tokens \
 **Expected response:**
 
 ```json
-{ "tokens": [] }
+{ "tokens": [], "total": 0, "limit": 50, "offset": 0 }
 ```
 
 ---
@@ -207,10 +208,10 @@ curl -s http://localhost:7007/api/service-tokens/$TOKEN_ID/audit \
     {
       "id": "<uuid>",
       "tokenId": "<TOKEN_ID>",
-      "action": "created",
-      "performedBy": "user:development/guest",
-      "occurredAt": "<timestamp>",
-      "reason": null
+      "event": "created",
+      "actor": "user:development/guest",
+      "metadata": {},
+      "occurredAt": "<timestamp>"
     }
   ]
 }
@@ -263,7 +264,10 @@ curl -s http://localhost:7007/api/service-tokens/$TOKEN_ID/audit \
   -H "Authorization: Bearer $TOKEN" | jq .
 ```
 
-**Expected:** Two events — `created` and `revoked` — with the reason `"testing revocation flow"`.
+**Expected:** Two events in newest-first order:
+
+- `revoked` with `metadata.reason = "testing revocation flow"`
+- `created` with empty `metadata`
 
 #### Filter the list by status
 
@@ -282,7 +286,7 @@ curl -s "http://localhost:7007/api/catalog/entities?limit=1" \
   -w "\nHTTP status: %{http_code}\n"
 ```
 
-**Expected:** HTTP `401 Unauthorized`. The revoked token is rejected.
+**Expected:** HTTP `401 Unauthorized` once revocation has propagated through the configured cache TTL. If your app keeps the default `serviceTokens.cacheTtlSeconds: 60`, wait up to 60 seconds; for deterministic local checks, set the TTL to `0`.
 
 ---
 
@@ -436,8 +440,8 @@ http://localhost:3000/admin/service-tokens
 
 **Expected:**
 - Two rows in the audit table:
-  1. **created** — `user:development/guest` — no reason
-  2. **revoked** (red chip) — `user:development/guest` — reason: `testing revocation via UI`
+  1. **revoked** (red chip) — `user:development/guest` — reason: `testing revocation via UI`
+  2. **created** — `user:development/guest` — no reason
 
 2. Click **Close**.
 
@@ -453,7 +457,7 @@ curl -s "http://localhost:7007/api/catalog/entities?limit=1" \
   -w "\nHTTP status: %{http_code}\n"
 ```
 
-**Expected:** HTTP `401 Unauthorized`. The revoked token is rejected by the backend.
+**Expected:** HTTP `401 Unauthorized` once revocation has propagated through the configured cache TTL. If your local app sets `serviceTokens.cacheTtlSeconds: 0`, this happens immediately.
 
 ---
 
@@ -488,3 +492,62 @@ The frontend page at `/admin/service-tokens`:
 - ✅ **Create token** button opens `CreateTokenDialog` — full form with name, description, group selector, scope checkboxes, expiry date, and a success step with copy-to-clipboard
 - ✅ **Revoke** button per row opens `RevokeDialog` — confirmation with optional reason, disabled for already-revoked tokens
 - ✅ **Audit** button per row opens `AuditLogDialog` — event table with action chips, actor, reason, and timestamp
+
+---
+
+## Path C — Playwright Smoke
+
+This path is a maintainer-oriented smoke test for the primary admin UI flow. It is designed to complement, not replace, the API path:
+
+- `scripts/test-api.sh` validates contract and auth behavior
+- Playwright validates that the user-facing create → audit → revoke flow still works
+
+### What it covers
+
+- page load at `/admin/service-tokens`
+- create dialog happy path
+- one-time raw token display after creation
+- audit log rendering
+- revoke flow
+- newest-first audit ordering after revoke
+
+### What it does not cover yet
+
+- every permission-denied branch
+- backend error state rendering
+- cross-browser matrix coverage
+- CI-managed ephemeral harness startup
+
+### Prerequisites
+
+- Node `22`
+- the plugin repo dependencies installed
+- a local Backstage harness already running
+- for the recommended maintainer loop, `/Users/adrian/src/my-portal`
+- `serviceTokens.cacheTtlSeconds: 0` in the harness local config so revocation checks are deterministic
+
+### Run the smoke test
+
+With your harness already running:
+
+```bash
+cd /path/to/backstage-service-token-plugin
+PLAYWRIGHT_BASE_URL=http://localhost:3000 npm run test:ui-smoke
+```
+
+Optional headed mode:
+
+```bash
+PLAYWRIGHT_BASE_URL=http://localhost:3000 npm run test:ui-smoke:headed
+```
+
+Expected:
+
+- the page loads successfully
+- the smoke test creates a uniquely named token for `group:default/platform`
+- the success dialog shows a raw token once
+- the audit dialog first shows `created`
+- the token is revoked with a reason
+- the audit dialog then shows `revoked` followed by `created`
+
+If you are using `/Users/adrian/src/my-portal`, refresh local `file:` dependencies with `yarn install` after plugin changes so the harness picks up the current package snapshot.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -57,7 +57,7 @@ cd my-portal
 Start the app in development mode:
 
 ```bash
-yarn dev
+yarn start
 ```
 
 This starts both the backend (port 7007) and the frontend (port 3000) in a single terminal. Wait until you see both of these lines:
@@ -67,7 +67,7 @@ This starts both the backend (port 7007) and the frontend (port 3000) in a singl
 [1] Rspack compiled successfully
 ```
 
-> **Tip:** `yarn dev` runs both processes together. If you prefer separate terminals, use `yarn workspace backend start` and `yarn workspace app start` in two separate shells.
+> **Tip:** `yarn start` runs both processes together. If you prefer separate terminals, use `yarn workspace backend start` and `yarn workspace app start` in two separate shells.
 
 ### ✅ Checkpoint 1
 
@@ -97,12 +97,6 @@ yarn --cwd packages/backend add @adriandantas/plugin-service-tokens-node
 yarn --cwd packages/app add @adriandantas/plugin-service-tokens
 ```
 
-Also install the Backstage permission backend (required for the permission policy in Part 5):
-
-```bash
-yarn --cwd packages/backend add @backstage/plugin-permission-backend
-```
-
 ### ✅ Checkpoint 2
 
 Run `yarn install` to make sure the workspace is consistent:
@@ -119,26 +113,12 @@ You should see no errors. If you see peer dependency warnings, they are safe to 
 
 *~5 minutes*
 
-Open `packages/backend/src/index.ts`. You'll see a file that looks like this:
+Open `packages/backend/src/index.ts`. You will see a file that already includes `plugin-permission-backend` and `plugin-permission-backend-module-allow-all-policy` from the scaffold.
+
+Add the service token plugin and auth handler module imports at the top, then register them **after** the existing permission lines:
 
 ```typescript
 import { createBackend } from '@backstage/backend-defaults';
-
-const backend = createBackend();
-
-backend.add(import('@backstage/plugin-app-backend'));
-backend.add(import('@backstage/plugin-catalog-backend'));
-// ... other plugins ...
-
-backend.start();
-```
-
-Add the service token plugin, the auth handler module, and the permission backend:
-
-```typescript
-import { createBackend } from '@backstage/backend-defaults';
-import { serviceTokensPlugin } from '@adriandantas/plugin-service-tokens-backend';
-import { serviceTokenHandlerModule } from '@adriandantas/plugin-service-tokens-node';
 
 const backend = createBackend();
 
@@ -146,14 +126,16 @@ backend.add(import('@backstage/plugin-app-backend'));
 backend.add(import('@backstage/plugin-catalog-backend'));
 // ... your other plugins ...
 
+// permission plugin — already present in the scaffold, DO NOT add it again
+backend.add(import('@backstage/plugin-permission-backend'));
+// NOTE: keep the allow-all policy for now; we will replace it in Part 5
+backend.add(import('@backstage/plugin-permission-backend-module-allow-all-policy'));
+
 // Service token plugin — REST API and token database
-backend.add(serviceTokensPlugin);
+backend.add(import('@adriandantas/plugin-service-tokens-backend'));
 
 // Auth handler — makes raw service tokens accepted by Backstage's auth layer
-backend.add(serviceTokenHandlerModule);
-
-// Permission backend — required for the permission policy
-backend.add(import('@backstage/plugin-permission-backend'));
+backend.add(import('@adriandantas/plugin-service-tokens-node'));
 
 backend.start();
 ```
@@ -161,7 +143,9 @@ backend.start();
 **Why two registrations?**
 
 - `serviceTokensPlugin` provides the REST API at `/api/service-tokens` and manages the token database.
-- `serviceTokenHandlerModule` registers the `backstage-service-token` external auth handler with Backstage's `core.auth` service. This is what makes raw service tokens accepted as valid credentials on *any* backend route — not just the service token API. It must be registered as a service factory (not a module init hook) because `core.auth` is constructed before module init hooks run.
+- `serviceTokenHandlerModule` registers the `backstage-service-token` external auth handler with Backstage's `core.auth` service. This is what makes raw service tokens accepted as valid credentials on *any* backend route — not just the service token API.
+
+> ⚠️ **Do not add `plugin-permission-backend` a second time.** A fresh Backstage scaffold already includes it. Adding it twice causes a startup crash: *"ExtensionPoint with ID 'permission.policy' is already registered"*.
 
 ### ✅ Checkpoint 3
 
@@ -179,10 +163,10 @@ You should see `Backend listening on :7007` with no import errors. Stop it (`Ctr
 
 *~2 minutes*
 
-Open `packages/app/src/App.tsx`. Find the `createApp` call and add the service token plugin to the `features` array:
+Open `packages/app/src/App.tsx` and add the service token plugin to the `features` array:
 
 ```typescript
-import { createApp } from '@backstage/frontend-app-api';
+import { createApp } from '@backstage/frontend-defaults';
 import serviceTokensPlugin from '@adriandantas/plugin-service-tokens';
 
 const app = createApp({
@@ -221,8 +205,6 @@ The plugin enforces three granular permissions on its API endpoints:
 | `service-tokens:write` | Create tokens |
 | `service-tokens:revoke` | Revoke tokens |
 
-All three are `ResourcePermission<'service-token'>`, making them compatible with Backstage RBAC plugins.
-
 > ⚠️ **If you already have a permission policy** in your app, do not create a new one — Backstage supports only one active policy at a time. Instead, add the service token permission checks to your existing `handle` method and skip to the "Register the policy" step below.
 
 **Create the policy file:**
@@ -240,11 +222,6 @@ import {
   PolicyQuery,
   PolicyQueryUser,
 } from '@backstage/plugin-permission-node';
-import {
-  serviceTokensReadPermission,
-  serviceTokensWritePermission,
-  serviceTokensRevokePermission,
-} from '@adriandantas/plugin-service-tokens-node';
 import { Config } from '@backstage/config';
 
 export class ServiceTokensPermissionPolicy implements PermissionPolicy {
@@ -254,6 +231,12 @@ export class ServiceTokensPermissionPolicy implements PermissionPolicy {
     request: PolicyQuery,
     user?: PolicyQueryUser,
   ): Promise<PolicyDecision> {
+    const {
+      serviceTokensReadPermission,
+      serviceTokensWritePermission,
+      serviceTokensRevokePermission,
+    } = await import('@adriandantas/plugin-service-tokens-node');
+
     const adminRefs =
       this.config.getOptionalStringArray(
         'serviceTokens.admin.userEntityRefs',
@@ -261,7 +244,6 @@ export class ServiceTokensPermissionPolicy implements PermissionPolicy {
 
     const isAdmin = adminRefs.includes(user?.info.userEntityRef ?? '');
 
-    // Grant all three service token permissions to admin users
     if (
       isPermission(request.permission, serviceTokensReadPermission) ||
       isPermission(request.permission, serviceTokensWritePermission) ||
@@ -270,7 +252,6 @@ export class ServiceTokensPermissionPolicy implements PermissionPolicy {
       return { result: isAdmin ? AuthorizeResult.ALLOW : AuthorizeResult.DENY };
     }
 
-    // Allow all other permissions — adjust to match your existing policy
     return { result: AuthorizeResult.ALLOW };
   }
 }
@@ -278,25 +259,36 @@ export class ServiceTokensPermissionPolicy implements PermissionPolicy {
 
 **Register the policy in your backend:**
 
-Back in `packages/backend/src/index.ts`, add the policy module:
+Back in `packages/backend/src/index.ts`, make **two changes together**:
+
+1. **Remove** the allow-all policy line (it conflicts with your custom policy).
+2. **Add** the custom policy module in its place.
+
+> ⚠️ **Critical — both changes must happen at the same time:**
+> - Removing the allow-all policy without adding a replacement causes: *"No policy module installed!"*
+> - Adding a custom policy without removing the allow-all causes: *"ExtensionPoint with ID 'permission.policy' is already registered"*
+> - Backstage only allows **one** policy module registered at a time.
+
+Your updated `index.ts` should look like this:
 
 ```typescript
 import { createBackend } from '@backstage/backend-defaults';
 import { createBackendModule, coreServices } from '@backstage/backend-plugin-api';
 import { policyExtensionPoint } from '@backstage/plugin-permission-node/alpha';
-import { serviceTokensPlugin } from '@adriandantas/plugin-service-tokens-backend';
-import { serviceTokenHandlerModule } from '@adriandantas/plugin-service-tokens-node';
 import { ServiceTokensPermissionPolicy } from './serviceTokensPermissionPolicy';
 
 const backend = createBackend();
 
 // ... your other plugins ...
 
-backend.add(serviceTokensPlugin);
-backend.add(serviceTokenHandlerModule);
+// permission plugin
 backend.add(import('@backstage/plugin-permission-backend'));
+// NOTE: the allow-all line has been REMOVED and replaced by permissionModuleServiceTokens below
 
-// Permission policy — grants all three service token permissions to users in config
+backend.add(import('@adriandantas/plugin-service-tokens-backend'));
+backend.add(import('@adriandantas/plugin-service-tokens-node'));
+
+// Permission policy — grants service token permissions to users listed in config
 const permissionModuleServiceTokens = createBackendModule({
   pluginId: 'permission',
   moduleId: 'service-tokens-policy',
@@ -324,48 +316,87 @@ backend.start();
 
 *~2 minutes*
 
-**Add admin users to `app-config.yaml`:**
-
-Open `app-config.yaml` (in the root of your Backstage app) and add the `serviceTokens` section:
+**Add the service token handler and admin users to `app-config.yaml`:**
 
 ```yaml
+backend:
+  auth:
+    externalAccess:
+      - type: backstage-service-token
+        options: {}
+
 serviceTokens:
   admin:
     userEntityRefs:
       - user:development/guest   # the default dev user — replace in production
 ```
 
-> ⚠️ **Not sure what your entity ref is?** When you sign in as guest in development, your entity ref is `user:development/guest`. This is the default and is what we'll use throughout this tutorial.
+> **Why `backend.auth.externalAccess`?** Backstage's auth layer only invokes external token handlers that are listed in this config. The `backstage-service-token` entry tells Backstage to route unrecognised tokens through the service token plugin's verifier. Without it, raw tokens are rejected with `Illegal token` even though the plugin is installed.
 
-> ⚠️ **Production note:** The `user:development/guest` default is intentionally permissive for local development. In production, replace this with the entity refs of your actual admin users (e.g. `user:default/alice`).
+> ⚠️ **Production note:** Replace `user:development/guest` with the entity refs of your actual admin users (e.g. `user:default/alice`) in production.
 
-**Add a dev database override to `app-config.local.yaml`:**
-
-Create (or open) `app-config.local.yaml` and add a dedicated SQLite file for the plugin. This keeps the service token data separate from the rest of the app's in-memory database:
+**Create `app-config.local.yaml`** with a dedicated SQLite file for the plugin:
 
 ```yaml
 backend:
   database:
     plugin:
       service-tokens:
-        connection: '/tmp/service-tokens.sqlite'
+        connection: 'packages/backend/tmp/service-tokens.sqlite'
+
+serviceTokens:
+  cacheTtlSeconds: 0
 ```
 
-> **Note:** `app-config.local.yaml` is gitignored by default. It's the right place for dev-only overrides.
+> **Note:** `app-config.local.yaml` is gitignored by default. It is the right place for dev-only overrides. Backstage resolves relative SQLite paths from the project root, and `packages/backend/tmp/` is the conventional location.
+>
+> Setting `cacheTtlSeconds: 0` makes the revocation step deterministic for this tutorial. In production, keep the default or tune it intentionally.
 
 ---
 
-## Part 7 — Start the app
+## Part 7 — Add a tutorial group to the catalog
 
-*~1 minute*
+*~3 minutes*
 
-Start both the backend and frontend:
+The plugin validates `groupEntityRef` against real `Group` entities in the Backstage catalog. Open `examples/org.yaml` and add:
 
-```bash
-yarn dev
+```yaml
+---
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: platform
+spec:
+  type: team
+  profile:
+    displayName: Platform
+  children: []
 ```
 
-Wait for both of these lines to appear:
+This gives us a stable group ref: `group:default/platform`
+
+Confirm that `app-config.yaml` includes `org.yaml` in `catalog.locations`. In a fresh app it is already there:
+
+```yaml
+catalog:
+  locations:
+    - type: file
+      target: ../../examples/org.yaml
+      rules:
+        - allow: [User, Group]
+```
+
+> **Why this matters:** If `org.yaml` is not listed, the backend will not ingest the `Group`, and token creation will fail with `groupEntityRef must reference an existing Group entity`.
+
+---
+
+## Part 8 — Start the app
+
+```bash
+yarn start
+```
+
+Wait for both lines:
 
 ```
 [0] Backend listening on :7007
@@ -374,43 +405,52 @@ Wait for both of these lines to appear:
 
 ### ✅ Checkpoint 5
 
-Open `http://localhost:3000/admin/service-tokens` in your browser.
-
-**Expected:** The page loads with a "Service Tokens" header, a filter bar, a **Create token** button, and an empty table. No 401 or 403 error is shown.
-
-If you see a 403 error, double-check that `user:development/guest` is in `serviceTokens.admin.userEntityRefs` in `app-config.yaml` and restart the backend.
+Open `http://localhost:3000/admin/service-tokens`. The page should load with a "Service Tokens" header, filter bar, and **Create token** button. No 401 or 403 error.
 
 ---
 
-## Part 8 — Test via the API
+## Part 9 — Verify the tutorial group exists
 
-*~10 minutes*
-
-Now let's prove the whole system works end-to-end with `curl`. Each step shows the command, the expected output, and what it proves.
-
-### Step A1 — Get a guest token
-
-The guest auth provider issues a short-lived Backstage identity token. Capture it:
+First get a guest token (same step as Part 10 Step A1):
 
 ```bash
 TOKEN=$(curl -s -X POST http://localhost:7007/api/auth/guest/refresh \
   -H 'Content-Type: application/json' \
   | jq -r '.backstageIdentity.token')
+```
 
+Then query the catalog:
+
+```bash
+curl -s "http://localhost:7007/api/catalog/entities?filter=kind=group" \
+  -H "Authorization: Bearer $TOKEN" \
+  | jq '.[] | {name: .metadata.name, namespace: (.metadata.namespace // "default"), ref: ("group:" + (.metadata.namespace // "default") + "/" + .metadata.name)}'
+```
+
+**Expected output includes:**
+
+```json
+{
+  "name": "platform",
+  "namespace": "default",
+  "ref": "group:default/platform"
+}
+```
+
+---
+
+## Part 10 — Test via the API
+
+### Step A1 — Get a guest token
+
+```bash
+TOKEN=$(curl -s -X POST http://localhost:7007/api/auth/guest/refresh \
+  -H 'Content-Type: application/json' \
+  | jq -r '.backstageIdentity.token')
 echo "TOKEN=$TOKEN"
 ```
 
-Verify it decodes to the guest identity:
-
-```bash
-echo "$TOKEN" | cut -d. -f2 | base64 -d 2>/dev/null | jq .
-```
-
-**Expected:** `"sub": "user:development/guest"` in the decoded payload.
-
-> ⚠️ **Tokens are short-lived.** If you get a 401 response on a later step, re-run this command to get a fresh token.
-
----
+> ⚠️ Tokens are short-lived. Re-run this command if you get 401 on later steps.
 
 ### Step A2 — List available scopes
 
@@ -418,24 +458,6 @@ echo "$TOKEN" | cut -d. -f2 | base64 -d 2>/dev/null | jq .
 curl -s http://localhost:7007/api/service-tokens/scopes \
   -H "Authorization: Bearer $TOKEN" | jq .
 ```
-
-**Expected:**
-
-```json
-{
-  "scopes": [
-    { "id": "catalog:read",       "description": "Read access to the Software Catalog API",       "plugin": "catalog" },
-    { "id": "catalog:write",      "description": "Write access to the Software Catalog API",      "plugin": "catalog" },
-    { "id": "techdocs:read",      "description": "Read access to TechDocs",                       "plugin": "techdocs" },
-    { "id": "scaffolder:read",    "description": "Read access to Scaffolder templates and tasks", "plugin": "scaffolder" },
-    { "id": "scaffolder:execute", "description": "Execute Scaffolder templates",                  "plugin": "scaffolder" }
-  ]
-}
-```
-
-**What this proves:** The backend is running, the plugin is registered, and the guest user has the permissions needed for the read path.
-
----
 
 ### Step A3 — Create a service token
 
@@ -446,61 +468,27 @@ RESPONSE=$(curl -s -X POST http://localhost:7007/api/service-tokens \
   -d '{
     "name": "tutorial-token",
     "description": "Created during the tutorial",
-    "groupEntityRef": "group:default/guests",
+    "groupEntityRef": "group:default/platform",
     "scopes": ["catalog:read"],
     "expiresInDays": 30
   }')
 
 echo "$RESPONSE" | jq .
-```
 
-**Expected:**
-
-```json
-{
-  "token": {
-    "id": "<uuid>",
-    "name": "tutorial-token",
-    "description": "Created during the tutorial",
-    "groupEntityRef": "group:default/guests",
-    "scopes": ["catalog:read"],
-    "createdBy": "user:development/guest",
-    "createdAt": "<timestamp>",
-    "expiresAt": "<timestamp>",
-    "status": "active"
-  },
-  "rawToken": "<opaque-token-string>"
-}
-```
-
-> ⚠️ **The `rawToken` is shown exactly once.** It is never stored — only its SHA-256 hash is persisted. Copy it now. You will need it in the next step.
-
-Capture the token ID and raw token for subsequent steps:
-
-```bash
 TOKEN_ID=$(echo "$RESPONSE" | jq -r '.token.id')
 RAW_TOKEN=$(echo "$RESPONSE" | jq -r '.rawToken')
-
-echo "TOKEN_ID=$TOKEN_ID"
-echo "RAW_TOKEN=$RAW_TOKEN"
 ```
 
----
+> ⚠️ `rawToken` is shown exactly once. Copy it now.
 
 ### Step A4 — Use the raw token against the Catalog API
-
-This is the key moment: a machine credential authenticating against Backstage.
 
 ```bash
 curl -s "http://localhost:7007/api/catalog/entities?limit=1" \
   -H "Authorization: Bearer $RAW_TOKEN" | jq .
 ```
 
-**Expected:** HTTP 200 with a JSON array containing at least one catalog entity.
-
-**What this proves:** The `serviceTokenHandlerModule` is correctly registered. Backstage's `core.auth` service accepted the raw token, resolved it to a service principal (`service-token:group:default/guests:tutorial-token`), and the Catalog API served the request.
-
----
+**Expected:** HTTP 200 with catalog entities.
 
 ### Step A5 — Inspect the audit log
 
@@ -508,25 +496,6 @@ curl -s "http://localhost:7007/api/catalog/entities?limit=1" \
 curl -s http://localhost:7007/api/service-tokens/$TOKEN_ID/audit \
   -H "Authorization: Bearer $TOKEN" | jq .
 ```
-
-**Expected:**
-
-```json
-{
-  "events": [
-    {
-      "id": "<uuid>",
-      "tokenId": "<TOKEN_ID>",
-      "action": "created",
-      "performedBy": "user:development/guest",
-      "occurredAt": "<timestamp>",
-      "reason": null
-    }
-  ]
-}
-```
-
----
 
 ### Step A6 — Revoke the token
 
@@ -540,8 +509,6 @@ curl -s -X DELETE http://localhost:7007/api/service-tokens/$TOKEN_ID \
 
 **Expected:** `HTTP status: 204`
 
----
-
 ### Step A7 — Confirm the raw token is rejected
 
 ```bash
@@ -550,150 +517,61 @@ curl -s "http://localhost:7007/api/catalog/entities?limit=1" \
   -w "\nHTTP status: %{http_code}\n"
 ```
 
-**Expected:** `HTTP status: 401`
-
-**What this proves:** Revocation works. The token is no longer accepted by the auth layer.
-
-> **Cache note:** Revocation takes effect within `cacheTtlSeconds` (default: 60 seconds). If you get a 200 immediately after revoking, wait a moment and try again.
-
-Also confirm the audit log now has two events:
-
-```bash
-curl -s http://localhost:7007/api/service-tokens/$TOKEN_ID/audit \
-  -H "Authorization: Bearer $TOKEN" | jq .
-```
-
-**Expected:** Two events — `created` and `revoked` — with the reason `"tutorial revocation test"`.
-
----
+**Expected:** `HTTP status: 401` immediately in this tutorial, because Part 6 sets `serviceTokens.cacheTtlSeconds: 0`.
 
 ### Step A8 — Test permission enforcement
 
-**Unauthenticated request (should get 401):**
+**Unauthenticated (should get 401):**
 
 ```bash
 curl -s -X POST http://localhost:7007/api/service-tokens \
   -H "Content-Type: application/json" \
-  -d '{"name":"should-fail","groupEntityRef":"group:default/guests","scopes":["catalog:read"]}' \
+  -d '{"name":"should-fail","groupEntityRef":"group:default/platform","scopes":["catalog:read"]}' \
   -w "\nHTTP status: %{http_code}\n"
 ```
 
-**Expected:** `HTTP status: 401`
-
-**Non-admin user (should get 403):**
-
-Temporarily remove `user:development/guest` from `app-config.yaml`:
-
-```yaml
-serviceTokens:
-  admin:
-    userEntityRefs: []   # empty — no admins
-```
-
-Restart the backend, get a fresh token, then try to create a token:
-
-```bash
-TOKEN=$(curl -s -X POST http://localhost:7007/api/auth/guest/refresh \
-  -H 'Content-Type: application/json' | jq -r '.backstageIdentity.token')
-
-curl -s -X POST http://localhost:7007/api/service-tokens \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"name":"should-fail","groupEntityRef":"group:default/guests","scopes":["catalog:read"]}' \
-  -w "\nHTTP status: %{http_code}\n"
-```
-
-**Expected:** `HTTP status: 403` with body `{"error":"Forbidden: admin access required"}`.
-
-Restore the original config and restart the backend before continuing.
-
----
+**Non-admin user (should get 403):** Temporarily set `userEntityRefs: []` in `app-config.yaml`, restart, get a fresh token, and retry the create call. Expected: `HTTP status: 403`. Restore the config before continuing.
 
 ### ✅ Checkpoint 6
 
-You've confirmed:
-- ✅ Backend is running and the plugin is registered
+- ✅ Backend running and plugin registered
 - ✅ Guest user has admin permission
-- ✅ Token creation works and returns a raw token
-- ✅ Raw token authenticates against the Catalog API
-- ✅ Revocation works and the token is rejected after revocation
-- ✅ Unauthenticated requests get 401, non-admin requests get 403
+- ✅ Token creation returns a raw token
+- ✅ Raw token authenticates against Catalog API
+- ✅ Revocation works — token rejected after revoke
+- ✅ Unauthenticated → 401; non-admin → 403
 
 ---
 
-## Part 9 — Test via the UI
+## Part 11 — Test via the UI
 
-*~5 minutes*
-
-Now do the same lifecycle through the browser. Make sure both the backend and frontend are running (`yarn dev`).
+Make sure `yarn start` is running.
 
 ### Step B1 — Navigate to the page
 
-Open `http://localhost:3000/admin/service-tokens`.
-
-**Expected:**
-- The page loads with the **"Service Tokens"** header.
-- A filter bar (Status dropdown + Group field) and a **Create token** button are visible.
-- The table shows an empty state: *"No service tokens yet"*.
-
----
+Open `http://localhost:3000/admin/service-tokens`. Expected: "Service Tokens" header, filter bar, **Create token** button, empty table.
 
 ### Step B2 — Create a token
 
-1. Click **Create token**.
-2. The **Create service token** dialog opens.
-3. Fill in the form:
-   - **Name:** `ui-tutorial-token`
-   - **Description:** `Created via UI during the tutorial`
-   - **Owning group:** select `group:default/guests`
-   - **Permissions:** check `catalog:read`
-   - **Expiry date:** leave the default (30 days)
-4. Click **Create token**.
-
-**Expected on success:** The dialog switches to a success step showing a green checkmark and the raw token in a monospace box with a copy icon.
-
-5. **Click the copy icon** to copy the raw token. You'll need it in Step B6.
-6. Click **Done**.
-
-**Expected after closing:** The table now shows one row for `ui-tutorial-token` with status **Active**.
-
----
+1. Click **Create token**
+2. Fill in: Name `ui-tutorial-token`, Group `group:default/platform`, Permission `catalog:read`
+3. Click **Create token**
+4. Copy the raw token shown in the success dialog
+5. Click **Done** — table shows one active row
 
 ### Step B3 — Filter the list
 
-1. In the **Status** dropdown, select `Active`.
-   - **Expected:** `ui-tutorial-token` remains visible.
-2. In the **Group** field, type `group:default/guests`.
-   - **Expected:** `ui-tutorial-token` still appears.
-3. Click **Clear** to reset both filters.
-
----
+Test the Status and Group filters, then click Clear.
 
 ### Step B4 — View the audit log
 
-1. Click the **Audit** button on the `ui-tutorial-token` row.
-2. The **Audit log** dialog opens.
-
-**Expected:** One row with event chip **created**, actor `user:development/guest`, and no reason.
-
-3. Click **Close**.
-
----
+Click **Audit** on the row. Expected: one `created` event.
 
 ### Step B5 — Revoke the token
 
-1. Click the **Revoke** button on the `ui-tutorial-token` row.
-2. The **Revoke token?** dialog opens.
-3. Enter reason: `tutorial revocation via UI`
-4. Click **Revoke**.
-
-**Expected after closing:** The `ui-tutorial-token` row now shows a **Revoked** status chip. The Revoke button is disabled.
-
----
+Click **Revoke**, enter reason `tutorial revocation via UI`, confirm. Expected: row shows **Revoked** status.
 
 ### Step B6 — Confirm the raw token is rejected
-
-Use the raw token you copied in Step B2:
 
 ```bash
 curl -s "http://localhost:7007/api/catalog/entities?limit=1" \
@@ -701,35 +579,21 @@ curl -s "http://localhost:7007/api/catalog/entities?limit=1" \
   -w "\nHTTP status: %{http_code}\n"
 ```
 
-**Expected:** `HTTP status: 401`
-
----
+**Expected:** `HTTP status: 401` immediately in this tutorial, because Part 6 sets `serviceTokens.cacheTtlSeconds: 0`.
 
 ### Step B7 — Confirm revocation in the audit log
 
-1. Click **Audit** on the `ui-tutorial-token` row.
-
-**Expected:** Two rows:
-1. **created** — `user:development/guest` — no reason
-2. **revoked** (red chip) — `user:development/guest` — reason: `tutorial revocation via UI`
-
----
+Click **Audit** again. Expected: two rows in newest-first order — `revoked` with the reason, then `created`.
 
 ### ✅ Checkpoint 7 — Tutorial complete
-
-You've built a Backstage app from scratch, installed and configured the service token plugin, and verified the full token lifecycle through both the API and the browser UI.
 
 ---
 
 ## Cleanup
 
-To reset all token state, remove the SQLite database file:
-
 ```bash
-rm /tmp/service-tokens.sqlite
+rm packages/backend/tmp/service-tokens.sqlite
 ```
-
-The file is recreated with fresh migrations on the next backend start.
 
 ---
 
@@ -737,21 +601,23 @@ The file is recreated with fresh migrations on the next backend start.
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| `401 Unauthorized` on all API calls | Guest token expired (they are short-lived) | Re-run the `curl -X POST .../guest/refresh` command |
-| `403 Forbidden` on all API calls | User not in `serviceTokens.admin.userEntityRefs` | Add `user:development/guest` to `app-config.yaml` and restart the backend |
-| Raw token still works after revocation | Token is cached (up to `cacheTtlSeconds` seconds) | Wait 60 seconds and try again, or set `cacheTtlSeconds: 0` in config |
-| `Cannot find module '@backstage/backend-defaults/auth'` | Plugin not resolved from app's `node_modules` | Ensure packages are installed as workspace dependencies (`yarn --cwd packages/backend add ...`) |
+| `401 Unauthorized` on all API calls | Guest token expired | Re-run the `guest/refresh` curl command |
+| `403 Forbidden` on all API calls | User not in `serviceTokens.admin.userEntityRefs` | Add `user:development/guest` to `app-config.yaml` and restart |
+| `groupEntityRef must reference an existing Group entity` | Tutorial group not in catalog | Complete Part 7, verify `catalog.locations`, restart backend |
+| Catalog group query returns `[]` | No `Group` entities loaded | Add `platform` group to `examples/org.yaml`, restart backend |
+| Raw token still works after revocation | Token is cached | For this tutorial, confirm `serviceTokens.cacheTtlSeconds: 0` is present in `app-config.local.yaml`; otherwise wait up to the configured TTL |
+| `ExtensionPoint with ID 'permission.policy' is already registered` | Two policy modules registered at once | Remove `plugin-permission-backend-module-allow-all-policy` from `index.ts` |
+| `No policy module installed!` | Allow-all was removed but no replacement added | Add `permissionModuleServiceTokens` to `index.ts` (Part 5) |
+| Frontend shows 403 on page load | Permission policy not registered | Confirm `permissionModuleServiceTokens` is in `index.ts` and backend was restarted |
+| `Cannot find module` errors | Plugin not installed in workspace | Run `yarn --cwd packages/backend add @adriandantas/...` |
 | Migrations not running | `database.migrations.skip: true` in config | Remove that config key for the `service-tokens` plugin |
-| Frontend shows 403 on page load | Permission policy not registered | Confirm `permissionModuleServiceTokens` is added to `index.ts` and the backend was restarted |
 
 ---
 
 ## What's next
 
-You now have a working foundation. Here's where to go from here:
-
-- **[Configuration Reference](configuration.md)** — tune token lifetime, cache TTL, and add custom scopes for your own plugins
-- **[REST API Reference](api.md)** — integrate service tokens into CI pipelines and automation scripts
-- **[Production Readiness Guide](production-readiness.md)** — group-based admin access, policy merging, cache tuning, and audit log retention
-- **[Architecture](architecture.md)** — understand how token verification works under the hood, including the auth handler wiring and scope propagation design
-- **[Scope Enforcement Runbook](runbooks/scope-enforcement.md)** — optional guide for enforcing token scopes on specific routes in your own plugins
+- **[Configuration Reference](configuration.md)** — tune token lifetime, cache TTL, and add custom scopes
+- **[REST API Reference](api.md)** — integrate service tokens into CI pipelines
+- **[Production Readiness Guide](production-readiness.md)** — group-based admin access, policy merging, audit log retention
+- **[Architecture](architecture.md)** — understand how token verification works under the hood
+- **[Scope Enforcement Runbook](runbooks/scope-enforcement.md)** — enforce token scopes on specific routes in your own plugins

--- a/package.json
+++ b/package.json
@@ -15,10 +15,14 @@
     "pack:node": "npm_config_cache=/tmp/npm-cache npm pack --dry-run --workspace packages/plugin-service-tokens-node",
     "storybook": "CI=1 STORYBOOK_DISABLE_TELEMETRY=1 HOME=/tmp storybook dev -p 6006",
     "storybook:build": "CI=1 STORYBOOK_DISABLE_TELEMETRY=1 HOME=/tmp storybook build",
-    "test": "node --test packages/*/src/*.test.js",
-    "test:backend": "node --test packages/plugin-service-tokens-backend/src/*.test.js",
+    "test": "npm run test:prepare && node --test packages/*/src/*.test.js",
+    "test:api-script": "bash scripts/test-api.sh",
+    "test:backend": "npm run test:prepare && node --test packages/plugin-service-tokens-backend/src/*.test.js",
     "test:frontend": "node --test packages/plugin-service-tokens/src/*.test.js",
-    "test:node": "node --test packages/plugin-service-tokens-node/src/*.test.js"
+    "test:node": "node --test packages/plugin-service-tokens-node/src/*.test.js",
+    "test:prepare": "npm rebuild better-sqlite3",
+    "test:ui-smoke": "playwright test",
+    "test:ui-smoke:headed": "playwright test --headed"
   },
   "engines": {
     "node": ">=22.0.0"
@@ -28,6 +32,7 @@
   ],
   "devDependencies": {
     "@changesets/cli": "^2.29.7",
+    "@playwright/test": "^1.32.3",
     "@storybook/addon-essentials": "^8.6.14",
     "@storybook/addon-interactions": "^8.6.14",
     "@storybook/react-webpack5": "^8.6.14",

--- a/packages/plugin-service-tokens/README.md
+++ b/packages/plugin-service-tokens/README.md
@@ -11,9 +11,14 @@ yarn --cwd packages/app add @adriandantas/plugin-service-tokens
 ## Usage
 
 ```ts
+import { createApp } from '@backstage/frontend-defaults';
 import serviceTokensPlugin from '@adriandantas/plugin-service-tokens';
 
-app.addFeatures([serviceTokensPlugin]);
+const app = createApp({
+  features: [serviceTokensPlugin],
+});
+
+export default app.createRoot();
 ```
 
 See the repository root documentation for complete setup, including the backend plugin and auth handler module.

--- a/packages/plugin-service-tokens/src/ServiceTokensPage.jsx
+++ b/packages/plugin-service-tokens/src/ServiceTokensPage.jsx
@@ -251,9 +251,9 @@ export function ServiceTokensPage() {
       setAuditEntries(
         (data.events ?? []).map(e => ({
           id: e.id,
-          event: e.action,
-          actorEntityRef: e.performedBy,
-          reason: e.reason ?? null,
+          event: e.event,
+          actorEntityRef: e.actor ?? null,
+          reason: e.metadata?.reason ?? null,
           createdAt: e.occurredAt,
         })),
       );

--- a/packages/plugin-service-tokens/src/components/RevokeDialog.jsx
+++ b/packages/plugin-service-tokens/src/components/RevokeDialog.jsx
@@ -65,7 +65,7 @@ export function RevokeDialog({
         h(
           Typography,
           { variant: 'body2', color: 'textSecondary' },
-          'This action cannot be undone. Any service using this token will immediately lose access.',
+          'This action cannot be undone. Services using this token lose access after revocation propagates through the configured cache TTL.',
         ),
         token &&
           h(

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,36 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3000';
+const harnessDir = process.env.PLAYWRIGHT_HARNESS_DIR;
+const useSystemChrome = process.env.PLAYWRIGHT_USE_SYSTEM_CHROME !== 'false';
+
+export default defineConfig({
+  testDir: './playwright',
+  fullyParallel: false,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  reporter: [['list'], ['html', { open: 'never' }]],
+  timeout: 90_000,
+  expect: {
+    timeout: 10_000,
+  },
+  use: {
+    ...devices['Desktop Chrome'],
+    baseURL,
+    headless: process.env.PLAYWRIGHT_HEADLESS !== 'false',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    channel: useSystemChrome ? 'chrome' : undefined,
+  },
+  outputDir: 'test-results',
+  webServer: harnessDir
+    ? {
+        command: 'yarn start',
+        cwd: harnessDir,
+        url: baseURL,
+        reuseExistingServer: true,
+        timeout: 180_000,
+      }
+    : undefined,
+});

--- a/playwright/service-tokens.smoke.spec.js
+++ b/playwright/service-tokens.smoke.spec.js
@@ -1,0 +1,95 @@
+import { test, expect } from '@playwright/test';
+
+function addDays(date, days) {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
+}
+
+function isoDate(daysFromNow) {
+  return addDays(new Date(), daysFromNow).toISOString().slice(0, 10);
+}
+
+async function maybeEnterGuest(page) {
+  const enterButton = page.getByRole('button', { name: /^Enter$/i });
+  if (await enterButton.count()) {
+    await enterButton.first().click();
+  }
+}
+
+async function selectMaterialOption(page, _label, optionName) {
+  const dialog = page.getByRole('dialog');
+  const field = dialog.getByRole('button').first();
+  await field.click();
+
+  const option = page
+    .getByRole('option', { name: optionName, exact: true })
+    .or(page.getByRole('menuitem', { name: optionName, exact: true }))
+    .or(page.getByText(optionName, { exact: true }));
+
+  await expect(option.first()).toBeVisible();
+  await option.first().click();
+}
+
+test('create, audit, and revoke a service token from the admin UI', async ({ page }) => {
+  const tokenName = `ui-smoke-${Date.now()}`;
+  const revokeReason = 'Playwright smoke revocation';
+
+  await page.goto('/admin/service-tokens');
+  await maybeEnterGuest(page);
+
+  await expect(page.getByRole('main').getByRole('heading', { name: 'Service Tokens' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Create token' })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Create token' }).click();
+
+  const createDialog = page.getByRole('dialog');
+  await expect(createDialog).toBeVisible();
+  await expect(createDialog.getByText('Create service token')).toBeVisible();
+
+  await createDialog.locator('input').first().fill(tokenName);
+  await createDialog.locator('textarea').first().fill('Created by the Playwright smoke test');
+  await selectMaterialOption(page, 'Owning group', 'platform');
+  await createDialog.getByRole('checkbox', { name: /catalog:read/i }).check();
+  await createDialog.locator('input[type="date"]').fill(isoDate(60));
+  await createDialog.getByRole('button', { name: 'Create token' }).click();
+
+  await expect(page.getByText('Token created')).toBeVisible();
+  const rawTokenText = page.getByText(/^bsst_[A-Za-z0-9_-]+$/).last();
+  await expect(rawTokenText).toBeVisible();
+
+  await createDialog.getByRole('button', { name: 'Done' }).click();
+  await expect(page.getByRole('dialog')).toBeHidden();
+
+  const row = page.getByRole('row', { name: new RegExp(tokenName) });
+  await expect(row).toBeVisible();
+  await expect(row).toContainText('Active');
+
+  await row.getByRole('button', { name: 'Audit' }).click();
+  const auditDialog = page.getByRole('dialog');
+  const closeAuditButton = auditDialog.getByRole('button', { name: /^Close$/ }).last();
+  await expect(auditDialog.getByText(`Audit log — ${tokenName}`)).toBeVisible();
+  const auditRows = auditDialog.getByRole('row');
+  await expect(auditRows).toHaveCount(2);
+  await expect(auditRows.nth(1)).toContainText('created');
+  await closeAuditButton.click();
+
+  await row.getByRole('button', { name: 'Revoke' }).click();
+  const revokeDialog = page.getByRole('dialog');
+  await expect(revokeDialog.getByText('Revoke token?')).toBeVisible();
+  await revokeDialog.locator('textarea').first().fill(revokeReason);
+  await revokeDialog.getByRole('button', { name: 'Revoke' }).click();
+
+  await expect(revokeDialog).toBeHidden();
+  await expect(row).toContainText('Revoked');
+  await expect(row.getByRole('button', { name: 'Revoke' })).toBeDisabled();
+
+  await row.getByRole('button', { name: 'Audit' }).click();
+  await expect(auditDialog.getByText(`Audit log — ${tokenName}`)).toBeVisible();
+  const updatedAuditRows = auditDialog.getByRole('row');
+  await expect(updatedAuditRows).toHaveCount(3);
+  await expect(updatedAuditRows.nth(1)).toContainText('revoked');
+  await expect(updatedAuditRows.nth(1)).toContainText(revokeReason);
+  await expect(updatedAuditRows.nth(2)).toContainText('created');
+  await closeAuditButton.click();
+});

--- a/scripts/test-api.sh
+++ b/scripts/test-api.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# test-api.sh — Runs Part 10 API tests (A1–A8) against a running Backstage instance
+# Usage: bash test-api.sh [base_url]
+# Default base URL: http://localhost:7007
+
+set -euo pipefail
+
+BASE="${1:-http://localhost:7007}"
+REVOKE_WAIT_SECONDS="${SERVICE_TOKENS_REVOKE_WAIT_SECONDS:-65}"
+REVOKE_POLL_INTERVAL_SECONDS="${SERVICE_TOKENS_REVOKE_POLL_INTERVAL_SECONDS:-5}"
+PASS=0
+FAIL=0
+
+# ── Colour helpers ────────────────────────────────────────────────────────────
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+pass() { echo -e "${GREEN}✅ PASS${RESET} — $1"; PASS=$((PASS+1)); }
+fail() { echo -e "${RED}❌ FAIL${RESET} — $1"; FAIL=$((FAIL+1)); }
+info() { echo -e "${YELLOW}▶${RESET} $1"; }
+header() { echo; echo -e "${BOLD}$1${RESET}"; echo "$(printf '─%.0s' {1..60})"; }
+
+# ── HTTP helper ───────────────────────────────────────────────────────────────
+# Returns "BODY\nSTATUS_CODE" — body on all lines except last, status on last
+http() {
+  local method="$1"; shift
+  local url="$1"; shift
+  curl -s -w "\n%{http_code}" -X "$method" "$url" "$@" 2>&1 || true
+}
+
+status_of() { echo "$1" | tail -1; }
+body_of()   { echo "$1" | sed '$d'; }
+
+assert_status() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    pass "$label (HTTP $actual)"
+  else
+    fail "$label — expected HTTP $expected, got HTTP $actual"
+  fi
+}
+
+assert_json_present() {
+  local label="$1" jq_expr="$2" input="$3"
+  if echo "$input" | jq -e "$jq_expr" >/dev/null 2>&1; then
+    pass "$label"
+  else
+    fail "$label — jq assertion failed: $jq_expr"
+  fi
+}
+
+# ── Step A1 — Get guest token ─────────────────────────────────────────────────
+header "Step A1 — Get a guest token"
+info "POST $BASE/api/auth/guest/refresh"
+
+resp=$(http POST "$BASE/api/auth/guest/refresh" \
+  -H 'Content-Type: application/json')
+code=$(status_of "$resp")
+body=$(body_of "$resp")
+
+if [ "$code" = "200" ]; then
+  TOKEN=$(echo "$body" | jq -r '.backstageIdentity.token // empty')
+  if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+    fail "A1 — 200 returned but backstageIdentity.token is missing"
+    echo "Body: $body"
+    exit 1
+  fi
+  pass "A1 — guest token obtained (${TOKEN:0:40}...)"
+else
+  fail "A1 — expected HTTP 200, got HTTP $code — body: $body"
+  exit 1
+fi
+
+# ── Step A2 — List scopes ─────────────────────────────────────────────────────
+header "Step A2 — List available scopes"
+info "GET $BASE/api/service-tokens/scopes"
+
+resp=$(http GET "$BASE/api/service-tokens/scopes" \
+  -H "Authorization: Bearer $TOKEN")
+code=$(status_of "$resp")
+body=$(body_of "$resp")
+
+assert_status "A2 — list scopes" "200" "$code"
+if [ "$code" = "200" ]; then
+  info "Scopes: $(echo "$body" | jq -r '[.scopes[].id] | join(", ")' 2>/dev/null || echo '?')"
+fi
+
+# ── Step A3 — Create a service token ─────────────────────────────────────────
+header "Step A3 — Create a service token"
+TOKEN_NAME="test-token-$(date +%s)"
+info "POST $BASE/api/service-tokens  (name: $TOKEN_NAME)"
+
+resp=$(http POST "$BASE/api/service-tokens" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"name\": \"$TOKEN_NAME\",
+    \"description\": \"Created by test-api.sh\",
+    \"groupEntityRef\": \"group:default/platform\",
+    \"scopes\": [\"catalog:read\"],
+    \"expiresInDays\": 1
+  }")
+code=$(status_of "$resp")
+body=$(body_of "$resp")
+
+assert_status "A3 — create token" "201" "$code"
+if [ "$code" = "201" ]; then
+  TOKEN_ID=$(echo "$body" | jq -r '.token.id // empty')
+  RAW_TOKEN=$(echo "$body" | jq -r '.rawToken // empty')
+  if [ -z "$TOKEN_ID" ] || [ -z "$RAW_TOKEN" ]; then
+    fail "A3 — response missing token.id or rawToken — body: $body"
+    exit 1
+  fi
+  info "Token ID : $TOKEN_ID"
+  info "Raw token: ${RAW_TOKEN:0:40}..."
+else
+  fail "A3 — body: $body"
+  exit 1
+fi
+
+# ── Step A4 — Use raw token against Catalog API ───────────────────────────────
+header "Step A4 — Raw token authenticates against Catalog API"
+info "GET $BASE/api/catalog/entities?limit=1"
+
+resp=$(http GET "$BASE/api/catalog/entities?limit=1" \
+  -H "Authorization: Bearer $RAW_TOKEN")
+code=$(status_of "$resp")
+body=$(body_of "$resp")
+
+assert_status "A4 — catalog access with raw token" "200" "$code"
+if [ "$code" = "200" ]; then
+  info "Entities returned: $(echo "$body" | jq 'length' 2>/dev/null || echo '?')"
+fi
+
+# ── Step A5 — Inspect audit log ───────────────────────────────────────────────
+header "Step A5 — Inspect the audit log"
+info "GET $BASE/api/service-tokens/$TOKEN_ID/audit"
+
+resp=$(http GET "$BASE/api/service-tokens/$TOKEN_ID/audit" \
+  -H "Authorization: Bearer $TOKEN")
+code=$(status_of "$resp")
+body=$(body_of "$resp")
+
+assert_status "A5 — audit log accessible" "200" "$code"
+if [ "$code" = "200" ]; then
+  assert_json_present "A5 — audit response includes events array" '.events | type == "array"' "$body"
+  info "Audit events: $(echo "$body" | jq '.events | length' 2>/dev/null || echo '?')"
+  echo "$body" | jq -r '.events[] | "  \(.event)"' 2>/dev/null || true
+fi
+
+# ── Step A6 — Revoke the token ────────────────────────────────────────────────
+header "Step A6 — Revoke the token"
+info "DELETE $BASE/api/service-tokens/$TOKEN_ID"
+
+resp=$(http DELETE "$BASE/api/service-tokens/$TOKEN_ID" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"reason": "test-api.sh revocation test"}')
+code=$(status_of "$resp")
+
+assert_status "A6 — revoke token" "204" "$code"
+
+# ── Step A7 — Confirm raw token is rejected ───────────────────────────────────
+header "Step A7 — Revoked token is rejected after revocation"
+info "GET $BASE/api/catalog/entities?limit=1  (with revoked raw token)"
+info "Polling up to ${REVOKE_WAIT_SECONDS}s for revocation to take effect"
+info "Tutorial/dev-guide path sets serviceTokens.cacheTtlSeconds: 0 for immediate rejection"
+
+a7_passed=false
+max_attempts=$(( REVOKE_WAIT_SECONDS / REVOKE_POLL_INTERVAL_SECONDS + 1 ))
+for i in $(seq 1 "$max_attempts"); do
+  resp=$(http GET "$BASE/api/catalog/entities?limit=1" \
+    -H "Authorization: Bearer $RAW_TOKEN")
+  code=$(status_of "$resp")
+  if [ "$code" = "401" ]; then
+    a7_passed=true
+    break
+  fi
+  if [ "$i" -lt "$max_attempts" ]; then
+    info "  attempt $i/$max_attempts — still HTTP $code, waiting ${REVOKE_POLL_INTERVAL_SECONDS}s..."
+    sleep "$REVOKE_POLL_INTERVAL_SECONDS"
+  fi
+done
+
+if $a7_passed; then
+  pass "A7 — revoked token rejected (HTTP 401)"
+else
+  fail "A7 — revoked token still accepted after ${REVOKE_WAIT_SECONDS}s — expected HTTP 401, got HTTP $code"
+  fail "     Hint: set serviceTokens.cacheTtlSeconds: 0 in your dev config for deterministic immediate revocation checks"
+fi
+
+# ── Step A8 — Unauthenticated request → 401 ──────────────────────────────────
+header "Step A8 — Unauthenticated request is rejected"
+info "POST $BASE/api/service-tokens  (no Authorization header)"
+
+resp=$(http POST "$BASE/api/service-tokens" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"should-fail","groupEntityRef":"group:default/platform","scopes":["catalog:read"]}')
+code=$(status_of "$resp")
+
+assert_status "A8 — unauthenticated request rejected" "401" "$code"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo
+printf '═%.0s' {1..60}; echo
+total=$((PASS+FAIL))
+if [ "$FAIL" -eq 0 ]; then
+  echo -e "${GREEN}${BOLD}All $total tests passed ✅${RESET}"
+else
+  echo -e "${RED}${BOLD}$FAIL / $total tests FAILED ❌${RESET}  ($PASS passed)"
+fi
+printf '═%.0s' {1..60}; echo
+
+[ "$FAIL" -eq 0 ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2708,6 +2708,13 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
+"@playwright/test@^1.32.3":
+  version "1.59.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.59.1.tgz#5c4d38eac84a61527af466602ae20277685a02d6"
+  integrity sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==
+  dependencies:
+    playwright "1.59.1"
+
 "@popperjs/core@^2.11.8":
   version "2.11.8"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
@@ -7531,6 +7538,11 @@ fscreen@^1.0.2:
   resolved "https://registry.yarnpkg.com/fscreen/-/fscreen-1.2.0.tgz#1a8c88e06bc16a07b473ad96196fb06d6657f59e"
   integrity sha512-hlq4+BU0hlPmwsFjwGGzZ+OZ9N/wq9Ljg/sq3pX+2CD7hrJsX9tJgWWK/wiNTFM212CLHWhicOoqwXyZGGetJg==
 
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 fsevents@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
@@ -9976,6 +9988,20 @@ pkg-dir@^4.1.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+playwright-core@1.59.1:
+  version "1.59.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.59.1.tgz#d8a2b28bcb8f2bd08ef3df93b02ae83c813244b2"
+  integrity sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==
+
+playwright@1.59.1:
+  version "1.59.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.59.1.tgz#f7b0ca61637ae25264cec370df671bbe1f368a4a"
+  integrity sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==
+  dependencies:
+    playwright-core "1.59.1"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 pluralize@^8.0.0:
   version "8.0.0"


### PR DESCRIPTION
## Summary
- align the frontend audit/revoke UI to the canonical service token contract
- normalize the public docs around the canonical API, tutorial, and maintainer test flow
- add API and Playwright smoke coverage against a local Backstage harness
- add Playwright tooling and ignore local test artifacts

## Testing
- `npm test`
- `bash scripts/test-api.sh http://localhost:7007`
- `PLAYWRIGHT_BASE_URL=http://localhost:3000 npm run test:ui-smoke`