### PR TITLE
docs: overhaul public and maintainer documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ node_modules
 dist
 coverage
 storybook-static
+site
 playwright-report
 test-results
 *.tgz

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ Treat these as locked unless the public contract is intentionally changed across
 - Treat tests as a major concern, not a cleanup step
 - Update docs and tests together when behavior, contract, or workflow changes
 - Keep documentation current whenever code, APIs, configuration, or maintainer workflow changes
+- Write `README.md` and general user-facing documentation with the standards of an experienced open source technical writer for Backstage-style projects: clear audience-aware structure, practical examples, accurate installation and usage guidance, and concise explanations that help new adopters succeed quickly
 - Add or update JSDoc where exported behavior, interfaces, or non-obvious logic need durable explanation
 - Keep commits reviewable and grouped by change type
 - Use Conventional Commits

--- a/README.md
+++ b/README.md
@@ -1,102 +1,66 @@
 # backstage-service-token-plugin
 
-> Long-lived, group-scoped service tokens for Backstage — with a full admin UI, audit log, and permission-based access control.
+> Long-lived, group-scoped service tokens for Backstage, with a dedicated admin UI, audit log, and permission-aware management API.
 
 [![Node 22](https://img.shields.io/badge/node-22-brightgreen)](https://nodejs.org/)
 [![Backstage](https://img.shields.io/badge/backstage-compatible-blue)](https://backstage.io/)
 [![Packages](https://img.shields.io/badge/packages-3-informational)](#packages)
 [![License: BUSL-1.1](https://img.shields.io/badge/license-BUSL--1.1-yellow)](LICENSE)
 
----
+## What This Plugin Does
 
-## What is this?
+Backstage's built-in auth model is centered on short-lived user tokens. That is a good fit for browser sessions, but it is awkward for CI jobs, automation, and service-to-service integrations that need stable credentials for backend APIs.
 
-Backstage's built-in auth model issues **short-lived user tokens** — great for browser sessions, but impractical for CI pipelines, scripts, and service-to-service integrations that need to call Backstage backend APIs without a human in the loop.
+This plugin adds service tokens that are:
 
-This plugin adds **service tokens**: named, group-scoped, long-lived credentials that are:
+- created and managed through an admin page at `/admin/service-tokens`
+- stored as SHA-256 hashes, with the raw token shown only once at creation time
+- scoped to a catalog group and resolved as a `service` principal
+- revocable, with audit events for creation and revocation
+- protected by granular admin permissions: `service-tokens:read`, `service-tokens:write`, and `service-tokens:revoke`
 
-- Created and managed through a dedicated admin UI
-- Stored as SHA-256 hashes — the raw token is shown **once** at creation and never again
-- Verified by a custom `backstage-service-token` external auth handler wired into Backstage's auth layer
-- Scoped to a catalog group — the token authenticates as a `service` principal with subject `service-token:<group>:<token-name>` (e.g. `service-token:group:default/platform:ci-pipeline`)
-- Revocable at any time, with an optional reason captured in the audit log
+## What This Plugin Does Not Do
 
----
+Service token scopes are metadata only. They are stored, displayed, and exposed through the API, but this plugin does not automatically enforce scope-level authorization on arbitrary Backstage routes.
 
-## Features
-
-| | |
-|---|---|
-| ✅ | Create named, group-scoped tokens with configurable scopes and expiry |
-| ✅ | Raw token shown **once** at creation — SHA-256 hashed at rest |
-| ✅ | Revoke tokens with optional reason |
-| ✅ | Full per-token audit log (`created`, `revoked` events) |
-| ✅ | Filter token list by status and owning group |
-| ✅ | Granular permission-based admin authorization (`service-tokens:read`, `service-tokens:write`, `service-tokens:revoke`) |
-| ✅ | In-memory token cache with configurable TTL |
-| ✅ | Automatic DB migrations via Knex (SQLite, Postgres, MySQL) |
-| ✅ | Built-in scope catalogue + custom scopes via config |
-| ✅ | Storybook stories for every UI component |
-
----
-
-## Security model (important)
-
-Service token **scopes are currently metadata only**. They are stored with the token, exposed in UI/API, and intended for policy decisions, but this plugin does **not** enforce scope-level authorization on arbitrary Backstage API routes.
-
-If your organization requires strict scope enforcement, implement checks in consuming plugins/policies before using broad service tokens in production.
-
-This plugin's security responsibilities are intentionally limited to token lifecycle controls (issuance, hashing at rest, verification, expiry, revocation, and audit trail) plus admin permission enforcement on service-token management APIs.
-
-Auth/authz behavior changes should include explicit documentation and, when breaking or security-significant, migration notes.
-
----
-
-## Framework prerequisites
-
-This plugin builds on two Backstage framework capabilities. Neither requires a specific provider — the recommendations below are the most common starting points.
-
-| Capability | What it does for this plugin | Recommended setup | Backstage docs |
-|---|---|---|---|
-| **Default auth policy** | Validates every inbound token (service or user) before your route handler runs | Built-in — active by default in `createBackend()`. Do **not** set `dangerouslyDisableDefaultAuthPolicy: true` in production. | [Auth service overview](https://backstage.io/docs/backend-system/core-services/auth) |
-| **Permission framework** | Enforces `service-tokens:read`, `service-tokens:write`, and `service-tokens:revoke` on token management endpoints | Install `@backstage/plugin-permission-backend` and wire a policy (see [Quick Start Step 4](#4-add-a-permission-policy)) | [Permission framework overview](https://backstage.io/docs/permissions/overview) |
-
-> If you are starting from scratch with either framework, the [Getting Started guide](docs/getting-started.md) includes wiring examples for both. You can also follow the linked Backstage docs independently before installing this plugin.
-
----
+If you need strict scope enforcement, implement those checks in the consuming plugin or permission policy. The plugin itself is responsible for token issuance, hashing at rest, verification, expiry, revocation, audit logging, and admin authorization around token management.
 
 ## Packages
 
-This workspace contains three packages that work together:
+This workspace publishes three packages:
 
-| Package | Role |
+| Package | Purpose |
 |---|---|
-| [`@adriandantas/plugin-service-tokens`](packages/plugin-service-tokens) | Frontend plugin — admin UI at `/admin/service-tokens` |
-| [`@adriandantas/plugin-service-tokens-backend`](packages/plugin-service-tokens-backend) | Backend plugin — REST API, Knex persistence, permission enforcement |
-| [`@adriandantas/plugin-service-tokens-node`](packages/plugin-service-tokens-node) | Shared node library — token verification, cache, auth handler module |
+| [`@adriandantas/plugin-service-tokens`](packages/plugin-service-tokens) | Frontend plugin that adds the admin UI |
+| [`@adriandantas/plugin-service-tokens-backend`](packages/plugin-service-tokens-backend) | Backend plugin with the REST API, persistence, and permission checks |
+| [`@adriandantas/plugin-service-tokens-node`](packages/plugin-service-tokens-node) | Shared node library with the auth handler module, permission exports, and token verification utilities |
 
----
+## Before You Install
+
+This plugin expects a Backstage app that already uses:
+
+- the new backend system with `createBackend()`
+- the new frontend system with `createApp({ features: [...] })`
+- the default auth policy enabled
+- the Backstage permission framework for admin authorization
+
+The [Getting Started guide](docs/getting-started.md) walks through these prerequisites in detail for an existing Backstage app. The [Tutorial](docs/tutorial.md) covers the full from-scratch experience.
 
 ## Quick Start
 
-### 1. Add the packages to your Backstage app
+### 1. Install the packages
 
-Install the published packages directly from npm under the `@adriandantas` scope.
-
-In your Backstage app repo, add local file dependencies:
-
-```json
-yarn --cwd packages/backend add @adriandantas/plugin-service-tokens-backend
-yarn --cwd packages/backend add @adriandantas/plugin-service-tokens-node
-```
+Add the published packages to your Backstage app:
 
 ```bash
+yarn --cwd packages/backend add @adriandantas/plugin-service-tokens-backend
+yarn --cwd packages/backend add @adriandantas/plugin-service-tokens-node
 yarn --cwd packages/app add @adriandantas/plugin-service-tokens
 ```
 
-### 2. Register the backend plugin
+### 2. Register the backend plugin and auth handler
 
-```typescript
+```ts
 // packages/backend/src/index.ts
 import { serviceTokensPlugin } from '@adriandantas/plugin-service-tokens-backend';
 import { serviceTokenHandlerModule } from '@adriandantas/plugin-service-tokens-node';
@@ -107,8 +71,8 @@ backend.add(serviceTokenHandlerModule);
 
 ### 3. Register the frontend plugin
 
-```typescript
-// packages/app/src/App.tsx (new frontend system)
+```ts
+// packages/app/src/App.tsx
 import { createApp } from '@backstage/frontend-defaults';
 import serviceTokensPlugin from '@adriandantas/plugin-service-tokens';
 
@@ -121,8 +85,14 @@ export default app.createRoot();
 
 ### 4. Add a permission policy
 
-```typescript
+```ts
 // packages/backend/src/serviceTokensPermissionPolicy.ts
+import {
+  AuthorizeResult,
+  isPermission,
+} from '@backstage/plugin-permission-common';
+import { PermissionPolicy } from '@backstage/plugin-permission-node';
+import { Config } from '@backstage/config';
 import {
   serviceTokensReadPermission,
   serviceTokensWritePermission,
@@ -130,26 +100,32 @@ import {
 } from '@adriandantas/plugin-service-tokens-node';
 
 class ServiceTokensPermissionPolicy implements PermissionPolicy {
+  constructor(private readonly config: Config) {}
+
   async handle(request, user) {
+    const adminRefs =
+      this.config.getOptionalStringArray('serviceTokens.admin.userEntityRefs') ?? [];
+
+    const isAdmin = adminRefs.includes(user?.info.userEntityRef ?? '');
+
     if (
       isPermission(request.permission, serviceTokensReadPermission) ||
       isPermission(request.permission, serviceTokensWritePermission) ||
       isPermission(request.permission, serviceTokensRevokePermission)
     ) {
-      const adminRefs = config.getOptionalStringArray('serviceTokens.admin.userEntityRefs') ?? [];
-      if (adminRefs.includes(user?.info.userEntityRef ?? '')) {
-        return { result: AuthorizeResult.ALLOW };
-      }
-      return { result: AuthorizeResult.DENY };
+      return {
+        result: isAdmin ? AuthorizeResult.ALLOW : AuthorizeResult.DENY,
+      };
     }
+
     return { result: AuthorizeResult.ALLOW };
   }
 }
 ```
 
-`serviceTokens.admin.userEntityRefs` remains a convenient config source for your policy, but the policy itself now grants three separate permissions. Existing policies that only check `serviceTokensAdminPermission` will grant read access only; update them before rollout if they should continue to allow token creation and revocation.
+Existing policies that still check only `serviceTokensAdminPermission` will grant read access only. Update them before rollout if those users should also create or revoke tokens.
 
-### 5. Configure
+### 5. Add minimal configuration
 
 ```yaml
 # app-config.yaml
@@ -160,66 +136,60 @@ serviceTokens:
       - user:default/bob
 ```
 
-That's it. Navigate to `/admin/service-tokens` in your Backstage app.
-
----
+At that point the admin UI is available at `/admin/service-tokens`.
 
 ## Using a Service Token
 
-Once a token is created, use it as a Bearer token against any Backstage backend API:
+Once a token is created, use it as a bearer token against any Backstage backend API:
 
 ```bash
-curl -s "https://your-backstage/api/catalog/entities?limit=10" \
-  -H "Authorization: Bearer <rawToken>"
+curl -s "https://your-backstage.example.com/api/catalog/entities?limit=10" \
+  -H "Authorization: Bearer <raw-token>"
 ```
 
-The token authenticates as the group it was scoped to. Revoked or expired tokens return `401 Unauthorized` after cache invalidation, bounded by `serviceTokens.cacheTtlSeconds`.
+The token authenticates as the group it was created for. Revoked or expired tokens eventually stop working once cache invalidation propagates, bounded by `serviceTokens.cacheTtlSeconds`.
 
----
+For deterministic local testing of immediate revocation, set `serviceTokens.cacheTtlSeconds: 0`.
 
-## 📚 Documentation
+## Security Notes
 
-| Document | Audience | Description |
+- Keep the default auth policy enabled. Do not set `backend.auth.dangerouslyDisableDefaultAuthPolicy: true` in production.
+- Treat service token scopes as advisory metadata unless you have added enforcement in consuming plugins or policies.
+- The raw token is shown once and cannot be retrieved later.
+- Audit responses use `{ "events": [...] }` and are returned newest-first.
+
+## Documentation
+
+Start here based on what you are trying to do:
+
+| Doc | Audience | Purpose |
 |---|---|---|
-| [Documentation Home](docs/index.md) | All audiences | Top-level docs index and suggested reading order |
-| [Getting Started](docs/getting-started.md) | Platform engineer | Complete install and wiring walkthrough |
-| [Configuration Reference](docs/configuration.md) | Platform engineer | Every config key, defaults, and examples |
-| [REST API Reference](docs/api.md) | Consumer / integrator | All endpoints, request/response shapes, error codes |
-| [Architecture](docs/architecture.md) | Contributor / advanced user | Package internals, token lifecycle, DB schema |
-| [Testing Guide](docs/testing.md) | Developer | End-to-end test walkthrough (API and UI paths) |
-| [Production Readiness](docs/production-readiness.md) | Platform engineer | Group-based admin access, policy merging, cache TTL, audit retention |
+| [Documentation Home](docs/index.md) | Everyone | Entry point and reading guide |
+| [Tutorial](docs/tutorial.md) | Evaluator or new adopter | End-to-end install in a fresh Backstage app |
+| [Getting Started](docs/getting-started.md) | Platform engineer | Integrate the plugin into an existing Backstage app |
+| [Configuration Reference](docs/configuration.md) | Platform engineer | Configure token TTL, scopes, and admin access |
+| [REST API Reference](docs/api.md) | Integrator | Request and response contracts for every endpoint |
+| [Testing Guide](docs/testing.md) | Adopter or operator | Validate the plugin through API, UI, and smoke checks |
+| [Production Readiness](docs/production-readiness.md) | Platform engineer | Hardening guidance for auth, policy, and operations |
+| [Architecture](docs/architecture.md) | Contributor | Internal design and package responsibilities |
+| [Contract Decisions](docs/contract-decisions.md) | Contributor or reviewer | Canonical public behavior that should stay stable |
+| [Developer Test Guide](docs/developer-test-guide.md) | Maintainer | Fast repeatable verification for unpublished changes |
 | [Release Guide](docs/releasing.md) | Maintainer | Changesets and npm publishing workflow |
 
----
+## Package READMEs
 
-## Migration note
+If you are looking at this project from npm package pages:
 
-This branch intentionally changes the permission model from a single `service-tokens.admin` check to three granular permissions:
-
-- `service-tokens:read`
-- `service-tokens:write`
-- `service-tokens:revoke`
-
-The deprecated `serviceTokensAdminPermission` export is kept only as a read-permission alias for transition purposes. If your existing Backstage policy checks only `serviceTokensAdminPermission`, users will still be able to read token data but will lose create and revoke access until the policy is updated.
-
----
-
-## Publication readiness checklist
-
-Before publishing the first release:
-
-- Add screenshots or GIFs for `/admin/service-tokens` (table + create + audit + revoke)
-- Wire CI status and npm version badges once the repository remote exists
-- Tag the first release (`v0.1.0` or `v1.0.0` per your semver strategy)
-- Keep docs publishing phased: 1) in-repo docs, 2) GitHub Pages publishing, 3) operator runbooks/cookbooks
-
----
+- [Frontend package README](packages/plugin-service-tokens/README.md)
+- [Backend package README](packages/plugin-service-tokens-backend/README.md)
+- [Node package README](packages/plugin-service-tokens-node/README.md)
 
 ## Development
 
 ### Prerequisites
 
-- Node.js 22 (via `nvm`)
+- Node.js 22
+- npm or Yarn workspace tooling
 
 ```bash
 nvm install 22
@@ -230,8 +200,6 @@ nvm use 22
 
 ```bash
 npm test
-
-# Focused package runs
 npm run test:backend
 npm run test:node
 npm run test:frontend
@@ -240,21 +208,9 @@ npm run test:frontend
 ### Preview docs
 
 ```bash
-npm run docs:serve
-```
-
-Serves the documentation site at `http://localhost:8000`. On first use, create the local Python venv and install MkDocs into it:
-
-```bash
-# On Debian/Ubuntu/WSL — install python3-venv first if not present
-sudo apt-get install -y python3-venv
-# Create the venv and install MkDocs (one-time)
 npm run docs:install
-# Then serve
 npm run docs:serve
 ```
-
-The venv is created at `.venv/` (gitignored). After the one-time install, only `npm run docs:serve` is needed.
 
 ### Run Storybook
 
@@ -268,21 +224,18 @@ npm run storybook
 npm run pack:dry-run
 ```
 
-Stories are available for all five UI components: `ServiceTokensTableView`, `ServiceTokensFilters`, `CreateTokenDialog`, `RevokeDialog`, and `AuditLogDialog`.
-
----
-
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md).
+See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution standards and the pull request checklist.
 
----
+`AGENTS.md` is also tracked in this repository to define expectations for coding agents working on the project.
+
+If you are iterating on unpublished package changes, use the maintainer-focused [Developer Test Guide](docs/developer-test-guide.md).
 
 ## License
 
 Business Source License 1.1 (BUSL-1.1).
 
-✅ Free for teams to self-host and use internally.  
-❌ Hosting this plugin (or a substantially similar managed service) for third parties requires a commercial license from the licensor.
+Free for internal self-hosted use. Hosting this plugin, or a substantially similar managed service, for third parties requires a commercial license from the licensor.
 
 See [LICENSE](LICENSE) for full terms.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,5 +1,9 @@
 # REST API Reference
 
+Audience: integrators and operators working directly with the token management API.
+
+Use this reference for request and response contracts, route permissions, and development-time authentication examples.
+
 The service token backend exposes its API at `/api/service-tokens`. Every endpoint requires a valid Backstage user session plus the route-specific permission listed below.
 
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,7 @@
 # Architecture
 
+Audience: contributors and advanced readers who need the internal design, not the install story.
+
 This document describes the internal design of the service token plugin — how the three packages fit together, how a token is created and verified, and the key design decisions that shaped the implementation.
 
 ---
@@ -269,6 +271,6 @@ The frontend package follows two conventions that differ from typical Backstage 
 - **Backend unit tests** use Node's built-in `node:test` runner with SQLite (via `better-sqlite3`) for database tests. No Jest, no Vitest.
 - **Frontend unit tests** use Node's built-in test runner for pure helper functions.
 - **UI component tests** use Storybook — each component has a dedicated story file covering all meaningful states.
-- **Integration tests** are run against the `super-dev-portal` reference app, which installs the plugin packages as local file dependencies.
+- **Integration tests** are run against a local Backstage harness app that installs the plugin packages and exercises the documented API and UI flows.
 
 See [Testing Guide](testing.md) for the full end-to-end test walkthrough.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,5 +1,9 @@
 # Configuration Reference
 
+Audience: platform engineers configuring the plugin in an existing Backstage app.
+
+Use this reference to tune token lifetime, cache behavior, admin access, and scope catalog entries.
+
 All configuration lives under the `serviceTokens` key in `app-config.yaml`. Every key is optional — the plugin ships with sensible defaults and will start without any configuration present.
 
 ---
@@ -107,7 +111,7 @@ serviceTokens:
 
 > **Important:** The default value (`user:development/guest`) is intentionally permissive for local development. Always set an explicit list in production.
 
-The permission check is delegated to your Backstage permission policy. The config value is read by the policy implementation — see [Getting Started § Step 4](getting-started.md#step-4--add-a-permission-policy) for the reference policy.
+The permission check is delegated to your Backstage permission policy. The config value is read by the policy implementation — see [Getting Started](getting-started.md) for the reference policy in Step 4.
 
 > **Migration note:** Older examples used a single `service-tokens.admin` permission. The current plugin uses three granular permissions instead. If you still check only `serviceTokensAdminPermission`, users will have read access only until you update your policy.
 

--- a/docs/contract-decisions.md
+++ b/docs/contract-decisions.md
@@ -1,5 +1,7 @@
 # Contract Decisions
 
+Audience: contributors and reviewers maintaining stable public behavior.
+
 This note records the canonical public behavior for the plugin where earlier LLM-assisted sessions left code, tests, and docs out of sync.
 
 These decisions are the source of truth for future edits unless the public contract is intentionally changed.

--- a/docs/developer-test-guide.md
+++ b/docs/developer-test-guide.md
@@ -1,66 +1,39 @@
 # Developer Test Guide
 
-This guide is the fastest reliable way to validate the plugin locally **before the packages are published to npm**.
+Audience: maintainers working on unpublished changes to this plugin.
 
-Use it when you are changing the plugin itself and want a maintainer-focused answer to one of these questions:
+Use this guide when you need fast, repeatable verification in a local Backstage harness before publishing new package versions.
 
-- Does the plugin still work in a real Backstage app?
-- Do local `file:` installs still behave correctly before publication?
-- Does the admin UI still support the core create → audit → revoke flow?
+By the end of this guide you should be able to answer:
 
-If you are validating the plugin as an adopter, start with the [Tutorial](tutorial.md). If you want the broad end-to-end operator flow after installation, use the [Testing Guide](testing.md). This guide is for maintainers iterating on unpublished changes.
+- does the plugin still work in a real Backstage app
+- do local `file:` installs still behave correctly
+- does the primary create -> audit -> revoke flow still work end to end
 
----
+For the adopter experience, use the [Tutorial](tutorial.md) or [Getting Started](getting-started.md). For the broader post-install validation path, use the [Testing Guide](testing.md).
 
 ## What This Guide Covers
 
-- Node 22 verification in this repo
-- Local `file:` installs into a Backstage app
-- A fast repeat harness using `my-portal`
-- API smoke coverage with `scripts/test-api.sh`
-- UI smoke coverage with Playwright
+- validating this repository before integration
+- maintaining a reusable local Backstage harness
+- running the API smoke path with `scripts/test-api.sh`
+- running the Playwright UI smoke path
+- revalidating local `file:` installs in a fresh app when needed
 
-The canonical contract for this guide matches:
+The canonical behavior for this guide matches:
 
 - [REST API Reference](api.md)
 - [Testing Guide](testing.md)
 - [Contract Decisions](contract-decisions.md)
 
-That means:
-
-- audit responses use `events` with `event`, `actor`, `metadata`, and `occurredAt`
-- audit events are returned newest-first
-- deterministic local revocation checks rely on `serviceTokens.cacheTtlSeconds: 0`
-
----
-
-## When To Use This Guide
-
-Use this guide instead of the main tutorial when:
-
-- you are validating unpublished package changes
-- you need local `file:` installs instead of npm packages
-- you want a repeatable maintainer loop against `/Users/adrian/src/my-portal`
-- you want both API and UI smoke checks without re-scaffolding a new app every time
-
-Use the tutorial instead when:
-
-- you want the adopter experience from scratch
-- you are checking docs readability for platform engineers
-- you want the simplest end-user install story
-
----
-
 ## Prerequisites
 
-Make sure these are available:
-
-- Node `22`
+- Node 22
 - Yarn
 - `jq`
 - `curl`
-- this plugin repo cloned locally
-- the local harness app at `/Users/adrian/src/my-portal`
+- this plugin repository cloned locally
+- a local Backstage harness app that you can start and reconfigure
 
 Check the toolchain:
 
@@ -78,17 +51,9 @@ source ~/.nvm/nvm.sh
 nvm use 22
 ```
 
-Expected:
-
-- `node --version` reports `v22.x`
-- Yarn is available
-- `jq` and `curl` are installed
-
----
-
 ## 1. Verify This Repo First
 
-From this repo:
+From this repository:
 
 ```bash
 cd /path/to/backstage-service-token-plugin
@@ -101,46 +66,35 @@ Expected:
 - all tests pass
 - all three packages pack successfully in dry-run mode
 
-If this fails, stop and fix the plugin repo before moving on.
+If this fails, fix the plugin repository before moving on to harness validation.
 
----
+## 2. Prepare a Reusable Local Harness
 
-## 2. Fast Repeat Path — Use `my-portal`
+Use any local Backstage app that you can restart quickly and modify safely. The harness should be configured to match the documented contract.
 
-This is the recommended maintainer loop after the first integration is working.
+Before starting the harness, verify:
 
-Why:
-
-- it is already aligned to the tutorial contract
-- it uses local `file:` dependencies from this repo
-- it is fast to re-run after plugin changes
-
-Before starting the harness, confirm these behaviors in `/Users/adrian/src/my-portal`:
-
-- `backend.auth.externalAccess` includes `backstage-service-token`
-- `serviceTokens.admin.userEntityRefs` includes `user:development/guest`
-- `serviceTokens.cacheTtlSeconds: 0` is set in local config
-- `group:default/platform` exists in `examples/org.yaml`
-- local `file:` dependencies have been refreshed with `yarn install`
+- `serviceTokens.admin.userEntityRefs` grants the guest or test user the service token permissions
+- `serviceTokens.cacheTtlSeconds: 0` is set in local config if you want deterministic revocation checks
+- the catalog includes at least one group you can use for token creation, such as `group:default/platform`
+- your harness can start both backend and frontend locally
 
 Then start the harness:
 
 ```bash
-cd /Users/adrian/src/my-portal
+cd /path/to/your-backstage-app
 yarn start
 ```
 
 Expected:
 
 - frontend serves on `http://localhost:3000`
-- backend listens on `http://localhost:7007`
-- no startup error occurs for the service token plugin
-
----
+- backend serves on `http://localhost:7007`
+- startup completes without plugin registration or permission-policy errors
 
 ## 3. Run the API Smoke Path
 
-From this repo, with `my-portal` running:
+With the harness running, execute the repository API smoke script:
 
 ```bash
 cd /path/to/backstage-service-token-plugin
@@ -151,27 +105,25 @@ Expected:
 
 - guest token acquisition succeeds
 - scope listing succeeds
-- token creation returns `201` and a one-time `rawToken`
-- raw token authenticates against the Catalog API
-- audit log returns an `events` array
+- token creation returns `201` with a one-time `rawToken`
+- the raw token authenticates against the Catalog API
+- audit responses use `{ "events": [...] }`
 - revoke returns `204`
-- revoked raw token is rejected with `401`
+- revoked raw tokens are rejected with `401`
 - unauthenticated create is rejected with `401`
 
-If this fails, treat it as a contract or harness issue first, not a Playwright issue.
-
----
+If this path fails, treat it as a contract, config, or harness issue before debugging Playwright.
 
 ## 4. Run the Playwright UI Smoke Path
 
-With `my-portal` already running:
+With the harness already running:
 
 ```bash
 cd /path/to/backstage-service-token-plugin
 PLAYWRIGHT_BASE_URL=http://localhost:3000 npm run test:ui-smoke
 ```
 
-Optional:
+Optional headed run:
 
 ```bash
 PLAYWRIGHT_BASE_URL=http://localhost:3000 npm run test:ui-smoke:headed
@@ -179,21 +131,17 @@ PLAYWRIGHT_BASE_URL=http://localhost:3000 npm run test:ui-smoke:headed
 
 Expected:
 
-- the service token page loads
-- the create dialog works for a unique token
-- the success dialog shows the raw token once
+- the page loads
+- the create dialog succeeds for a unique token
+- the success dialog shows a raw token once
 - the audit dialog shows `created`
 - revoke succeeds
 - the table shows `Revoked`
-- the audit dialog shows newest-first ordering: `revoked`, then `created`
+- the audit dialog shows newest-first ordering after revoke
 
-This smoke test intentionally covers only the primary happy path. It does not yet validate every permission or error branch.
+## 5. Revalidate Local `file:` Installs in a Fresh App
 
----
-
-## 5. Fresh App Path — Revalidate Local `file:` Installs
-
-Use this path when you want to prove the plugin still works in a newly scaffolded Backstage app before publication.
+Use this path when you want to prove unpublished package changes still work in a newly scaffolded Backstage app.
 
 Create a fresh app:
 
@@ -204,52 +152,14 @@ cd /tmp
 npx @backstage/create-app@latest
 ```
 
-Move into the new app:
+Move into the app and install dependencies:
 
 ```bash
 cd /tmp/service-token-dev-test
-```
-
-Reinstall under Node 22:
-
-```bash
 yarn install
 ```
 
-Expected:
-
-- the clean app starts before plugin changes
-- Node 22 is the active runtime for native modules
-
----
-
-## 6. Install the Plugin From Local Package Folders
-
-Use this plugin repo path as an example:
-
-```text
-/path/to/backstage-service-token-plugin
-```
-
-Add a root Yarn resolution before backend install so the local node package is used consistently:
-
-```json
-"resolutions": {
-  "@types/react": "^18",
-  "@types/react-dom": "^18",
-  "@adriandantas/plugin-service-tokens-node@npm:^0.1.0": "file:/path/to/backstage-service-token-plugin/packages/plugin-service-tokens-node"
-}
-```
-
-If `resolutions` already exists, add the service-token entry rather than replacing existing values.
-
-Then run:
-
-```bash
-yarn install
-```
-
-Install the plugin packages with local `file:` paths:
+Then install the plugin packages from local folders:
 
 ```bash
 yarn --cwd packages/backend add \
@@ -262,65 +172,37 @@ yarn --cwd packages/app add \
   @adriandantas/plugin-service-tokens@file:/path/to/backstage-service-token-plugin/packages/plugin-service-tokens
 ```
 
-Then run:
+If your app needs a root `resolutions` entry so the local node package is used consistently, add it deliberately and keep any existing values intact.
 
-```bash
-yarn install
-```
+After install, wire the app to match the documented tutorial contract:
 
-Expected:
+- register the backend plugin
+- register the service token auth handler module
+- register the frontend plugin in `createApp({ features: [...] })`
+- configure admin users and, if needed, `serviceTokens.cacheTtlSeconds: 0` for deterministic revocation checks
 
-- installs succeed
-- peer warnings may appear
-- the local packages are materialized into the app successfully
+Then run the same API and UI smoke paths.
 
----
+## 6. What to Record When Something Fails
 
-## 7. Wire the Fresh App to Match the Tutorial Contract
+Capture enough detail to tell whether the issue belongs to this repository, the harness app, or the local installation flow:
 
-Use the [Tutorial](tutorial.md) and [Getting Started](getting-started.md) documents as the canonical wiring reference.
-
-For parity, the fresh app should end up with:
-
-- backend plugin registration
-- auth handler registration
-- custom permission policy
-- `backend.auth.externalAccess` for `backstage-service-token`
-- `serviceTokens.admin.userEntityRefs` including `user:development/guest`
-- `serviceTokens.cacheTtlSeconds: 0` in local config
-- `group:default/platform` present in the catalog
-- frontend registration of `serviceTokensPlugin`
-
-Expected:
-
-- `/admin/service-tokens` loads without `401` or `403`
-- API and UI smoke paths behave the same way as the maintainer harness
-
----
-
-## 8. What To Record If Something Fails
-
-Capture:
-
-- the exact command you ran
-- the exact error output
-- whether the failure was in this repo, `my-portal`, or a fresh app
-- whether the failure was in the API smoke path or the Playwright smoke path
-- whether the failure was contract-related, install-related, or harness-related
-
-That keeps maintainer debugging grounded in facts instead of assumptions.
-
----
+- the exact command that failed
+- backend and frontend logs
+- whether the failure reproduced in the reusable harness, a fresh app, or both
+- whether the mismatch is in behavior, docs, or packaging
+- whether the failure affects the public contract in [Contract Decisions](contract-decisions.md)
 
 ## Recommended Maintainer Loop
 
 For day-to-day iteration:
 
-1. Change the plugin
-2. Run `npm test`
-3. Refresh `my-portal` with `yarn install` if package contents changed
-4. Start `my-portal`
-5. Run `npm run test:api-script -- http://localhost:7007`
-6. Run `PLAYWRIGHT_BASE_URL=http://localhost:3000 npm run test:ui-smoke`
+1. Make the plugin change in this repository.
+2. Run `npm test`.
+3. Run `npm run pack:dry-run` if package contents may have changed.
+4. Refresh the local harness dependencies if you are using local `file:` installs.
+5. Start or restart the harness.
+6. Run `npm run test:api-script -- http://localhost:7007`.
+7. Run `PLAYWRIGHT_BASE_URL=http://localhost:3000 npm run test:ui-smoke`.
 
-That gives quick confidence in both contract behavior and the main admin UI path before publication work begins.
+That sequence gives quick confidence in both the public contract and the primary admin UI flow before release work begins.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,5 +1,9 @@
 # Getting Started
 
+Audience: platform engineers wiring the plugin into an existing Backstage app.
+
+Use this guide when your Backstage app already exists and you want the shortest supported path to installation, configuration, and a working smoke test.
+
 This guide walks a platform engineer through installing and wiring the service token plugin into an existing Backstage application. By the end you will have:
 
 - The backend plugin running and serving the REST API at `/api/service-tokens`

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,49 +1,38 @@
 # Backstage Service Token Plugin Docs
 
-Welcome to the documentation for the **Backstage Service Token Plugin**.
+These docs are organized by audience so adopters can move quickly, while maintainers still have a clear place for internal workflows.
 
-This plugin provides:
+## Start Here
 
-- A backend API for creating, listing, and revoking service tokens
-- An external auth handler so raw service tokens can authenticate against Backstage backend routes
-- A frontend admin page at `/admin/service-tokens`
-- Granular permission-based administration via `service-tokens:read`, `service-tokens:write`, and `service-tokens:revoke`
+Choose the path that matches your job:
 
----
+- [Tutorial](tutorial.md) for the full from-scratch experience in a new Backstage app
+- [Getting Started](getting-started.md) to install the plugin into an existing Backstage app
+- [Configuration Reference](configuration.md) to tune behavior and policy inputs
+- [REST API Reference](api.md) to integrate against the token management endpoints
+- [Testing Guide](testing.md) to validate the plugin after installation
+- [Production Readiness](production-readiness.md) to harden the setup for real environments
 
-## Start here
+## Adopters and Operators
 
-- [Tutorial](tutorial.md) — build a Backstage app from scratch and integrate the plugin end-to-end (~30 min)
-- [Getting Started](getting-started.md) — install and wire the plugin into an existing Backstage app
-- [Configuration Reference](configuration.md) — all `serviceTokens` config keys and defaults
-- [REST API Reference](api.md) — request/response formats for all endpoints
-- [Contract Decisions](contract-decisions.md) — canonical public behavior where earlier sessions diverged
-- [Architecture](architecture.md) — package design, token lifecycle, and database model
-- [Testing Guide](testing.md) — end-to-end API and UI test flows
-- [Developer Test Guide](developer-test-guide.md) — fastest local integration path before npm publication
-- [Release Guide](releasing.md) — versioning and publishing the npm packages
-- [Production Readiness](production-readiness.md) — group-based admin access, policy merging, cache tuning, audit retention
-- [Scope Enforcement Runbook](runbooks/scope-enforcement.md) — optional operator guidance for consumer-driven enforcement
+- [Tutorial](tutorial.md)
+- [Getting Started](getting-started.md)
+- [Configuration Reference](configuration.md)
+- [REST API Reference](api.md)
+- [Testing Guide](testing.md)
+- [Production Readiness](production-readiness.md)
+- [Scope Enforcement Runbook](runbooks/scope-enforcement.md)
 
----
+## Contributors and Advanced Readers
 
-## Suggested reading order
+- [Architecture](architecture.md)
+- [Contract Decisions](contract-decisions.md)
 
-1. Begin with [Getting Started](getting-started.md)
-2. Tune settings in [Configuration Reference](configuration.md)
-3. Integrate automation using [REST API Reference](api.md)
-4. Dive deeper with [Architecture](architecture.md)
-5. Validate your setup with [Testing Guide](testing.md)
-6. Publish updates with [Release Guide](releasing.md)
-7. Harden for production with the [Production Readiness Guide](production-readiness.md)
-8. Optionally enforce token scopes with the [Scope Enforcement Runbook](runbooks/scope-enforcement.md)
+`Contract Decisions` is the canonical reference for stable public behavior when code, tests, and documentation have previously drifted.
 
----
+## Maintainers
 
-## Documentation publishing roadmap
+- [Developer Test Guide](developer-test-guide.md)
+- [Release Guide](releasing.md)
 
-Documentation publishing follows a phased model:
-
-1. Keep in-repo docs complete and decision-oriented.
-2. Publish docs to GitHub Pages with minimal tooling first, then harden navigation/versioning.
-3. Add operator runbooks/cookbooks for enforcement patterns and incident handling.
+These docs are intentionally maintainer-oriented. They cover unpublished package testing, local file-based verification, and npm release workflow rather than the adopter install story.

--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -1,5 +1,9 @@
 # Production Readiness Guide
 
+Audience: platform engineers preparing the plugin for production Backstage environments.
+
+Use this guide after installation is working and you are ready to harden policy, cache behavior, and operational practices.
+
 This guide covers what you need to verify, configure, and decide before running the service token plugin in a production Backstage deployment. It assumes you have already completed the [Getting Started](getting-started.md) walkthrough.
 
 ---
@@ -15,7 +19,7 @@ Run through this before going live. Each item links to the relevant section belo
 - [ ] `serviceTokens.cacheTtlSeconds` is tuned to match your revocation SLO (see [Cache TTL and revocation SLO](#cache-ttl-and-revocation-slo))
 - [ ] `serviceTokens.maxTokenLifetimeDays` is set to a value appropriate for your security policy
 - [ ] Audit log retention is understood and covered by your logging infrastructure (see [Audit log retention](#audit-log-retention))
-- [ ] At least one smoke test has been run against the production backend (see [Getting Started § Step 7](getting-started.md#step-7--smoke-test))
+- [ ] At least one smoke test has been run against the production backend (see [Getting Started](getting-started.md) for the smoke-test flow in Step 7)
 
 ---
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,5 +1,9 @@
 # Releasing to npm
 
+Audience: maintainers publishing new package versions from this repository.
+
+Use this guide after code, tests, and documentation are already aligned and ready to ship.
+
 This repository publishes three public scoped packages:
 
 - `@adriandantas/plugin-service-tokens`
@@ -72,3 +76,4 @@ Run that command from the package directory you want to publish.
 - Confirm each package page exists on npm
 - Confirm the package README renders correctly
 - Confirm the install snippets in `README.md` still match the published versions
+- Confirm the docs still describe the current auth, permission, and scope-enforcement behavior accurately

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,8 +1,15 @@
 # Testing the Service Token Plugin
 
-This guide walks through exercising the `backstage-service-token-plugin` end-to-end against a local Backstage integration harness.
+Audience: adopters and operators validating an installed plugin in a local or pre-production Backstage environment.
 
-> **Maintainer note:** If you are iterating on unpublished plugin changes, use the [Developer Test Guide](developer-test-guide.md) for the fastest repeatable path with `/Users/adrian/src/my-portal`. This guide stays focused on the adopter-style end-to-end flows.
+Use this guide to confirm the plugin works end to end after installation. For unpublished package work or local `file:` installs, use the maintainer-focused [Developer Test Guide](developer-test-guide.md).
+
+By the end of this guide you should be able to verify:
+
+- the admin UI loads and performs the main token lifecycle actions
+- the REST API returns the documented request and response shapes
+- raw service tokens authenticate against Backstage backend routes
+- revocation and permission checks behave as expected
 
 The frontend UI at `/admin/service-tokens` provides a full page experience: token list with filters, a **Create token** button, and **Audit** / **Revoke** actions per row — all wired to the backend. Choose the path that suits your workflow:
 
@@ -12,9 +19,9 @@ The frontend UI at `/admin/service-tokens` provides a full page experience: toke
 
 | Path | What it tests |
 |------|---------------|
-| [Path A — API Testing](#path-a--api-testing) | Full end-to-end via `curl` — no browser required |
-| [Path B — UI Testing](#path-b--ui-testing) | Full end-to-end via the browser UI |
-| [Path C — Playwright Smoke](#path-c--playwright-smoke) | Maintainer-oriented create → audit → revoke UI smoke path |
+| Path A — API Testing | Full end-to-end via `curl` — no browser required |
+| Path B — UI Testing | Full end-to-end via the browser UI |
+| Path C — Playwright Smoke | Focused create → audit → revoke UI smoke path |
 
 Paths A and B cover the same scenarios (create, list, audit, revoke, permission enforcement). Path C is intentionally narrower: it validates the primary admin UI flow against a local harness. You can also mix the paths — for example, create via the UI and verify via the API.
 
@@ -32,19 +39,17 @@ nvm use 22
 ### 2. Start the backend
 
 ```bash
-cd /home/roberto/projects/super-dev-portal
-source ~/.nvm/nvm.sh && nvm use 22
-node .yarn/releases/yarn-4.4.1.cjs workspace backend start 2>&1 | tee /tmp/backend.log
+cd /path/to/your-backstage-app
+yarn workspace backend start
 ```
 
-Wait until you see `Listening on :7007` in the output.
+Wait until the backend is listening on `http://localhost:7007`.
 
 ### 3. Start the frontend (separate terminal)
 
 ```bash
-cd /home/roberto/projects/super-dev-portal
-source ~/.nvm/nvm.sh && nvm use 22
-node .yarn/releases/yarn-4.4.1.cjs workspace app start 2>&1 | tee /tmp/frontend.log
+cd /path/to/your-backstage-app
+yarn workspace app start
 ```
 
 Wait until you see `Rspack compiled successfully` in the output.
@@ -497,7 +502,7 @@ The frontend page at `/admin/service-tokens`:
 
 ## Path C — Playwright Smoke
 
-This path is a maintainer-oriented smoke test for the primary admin UI flow. It is designed to complement, not replace, the API path:
+This path is a focused smoke test for the primary admin UI flow. It is designed to complement, not replace, the API path:
 
 - `scripts/test-api.sh` validates contract and auth behavior
 - Playwright validates that the user-facing create → audit → revoke flow still works
@@ -523,7 +528,6 @@ This path is a maintainer-oriented smoke test for the primary admin UI flow. It 
 - Node `22`
 - the plugin repo dependencies installed
 - a local Backstage harness already running
-- for the recommended maintainer loop, `/Users/adrian/src/my-portal`
 - `serviceTokens.cacheTtlSeconds: 0` in the harness local config so revocation checks are deterministic
 
 ### Run the smoke test
@@ -550,4 +554,4 @@ Expected:
 - the token is revoked with a reason
 - the audit dialog then shows `revoked` followed by `created`
 
-If you are using `/Users/adrian/src/my-portal`, refresh local `file:` dependencies with `yarn install` after plugin changes so the harness picks up the current package snapshot.
+If your local harness uses `file:` dependencies, refresh them with `yarn install` after package changes so the app picks up the current package snapshot.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,5 +1,9 @@
 # Build a Backstage App with Service Token Support — End-to-End Tutorial
 
+Audience: evaluators and adopters starting from a fresh Backstage app.
+
+Use this guide when you want to experience the full setup journey from scaffolding a new app through validating the plugin in both API and UI flows.
+
 > **Estimated time:** ~30 minutes  
 > **Difficulty:** Beginner-friendly — no prior Backstage experience required
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,10 +10,14 @@ nav:
   - REST API: api.md
   - Architecture: architecture.md
   - Testing: testing.md
-  - Releasing: releasing.md
   - Production Readiness: production-readiness.md
   - Runbooks:
       - Scope Enforcement: runbooks/scope-enforcement.md
+  - Reference:
+      - Contract Decisions: contract-decisions.md
+  - Maintainers:
+      - Developer Test Guide: developer-test-guide.md
+      - Releasing: releasing.md
 
 theme:
   name: material

--- a/packages/plugin-service-tokens-backend/README.md
+++ b/packages/plugin-service-tokens-backend/README.md
@@ -2,6 +2,14 @@
 
 Backend Backstage plugin for creating, listing, auditing, and revoking service tokens.
 
+This package provides:
+
+- the `/api/service-tokens` REST API
+- database persistence and migrations
+- permission checks for read, write, and revoke operations
+
+It should be installed together with `@adriandantas/plugin-service-tokens-node`, which supplies the external auth handler module used to validate raw service tokens.
+
 ## Install
 
 ```bash
@@ -19,4 +27,6 @@ backend.add(serviceTokensPlugin);
 backend.add(serviceTokenHandlerModule);
 ```
 
-See the repository root documentation for full install, configuration, and permission policy wiring.
+This package expects the Backstage permission framework to be installed and a permission policy to grant `service-tokens:read`, `service-tokens:write`, and `service-tokens:revoke`.
+
+For the full installation flow, policy wiring, and config reference, see the root [README](../../README.md) and [Getting Started guide](../../docs/getting-started.md).

--- a/packages/plugin-service-tokens-node/README.md
+++ b/packages/plugin-service-tokens-node/README.md
@@ -1,6 +1,8 @@
 # @adriandantas/plugin-service-tokens-node
 
-Shared Backstage node library that exposes the service token auth handler module and supporting primitives.
+Shared Backstage node library for the service token auth handler, permission exports, and verification utilities.
+
+This package is primarily used by the backend plugin, but it also exposes the pieces you need when wiring auth and permission policies.
 
 ## Install
 
@@ -10,10 +12,18 @@ yarn --cwd packages/backend add @adriandantas/plugin-service-tokens-node
 
 ## Usage
 
+Register the auth handler module in your backend:
+
 ```ts
 import { serviceTokenHandlerModule } from '@adriandantas/plugin-service-tokens-node';
 
 backend.add(serviceTokenHandlerModule);
 ```
 
-See the repository root documentation for the full installation flow and backend configuration requirements.
+This package also exports the service token permission definitions used in permission policies:
+
+- `serviceTokensReadPermission`
+- `serviceTokensWritePermission`
+- `serviceTokensRevokePermission`
+
+For the complete installation flow and backend integration guidance, see the root [README](../../README.md) and [Getting Started guide](../../docs/getting-started.md).

--- a/packages/plugin-service-tokens/README.md
+++ b/packages/plugin-service-tokens/README.md
@@ -1,6 +1,11 @@
 # @adriandantas/plugin-service-tokens
 
-Frontend Backstage plugin for managing service tokens from `/admin/service-tokens`.
+Frontend Backstage plugin that adds the service token admin page at `/admin/service-tokens`.
+
+Use this package together with:
+
+- `@adriandantas/plugin-service-tokens-backend` for the REST API and persistence
+- `@adriandantas/plugin-service-tokens-node` for the auth handler module used by the backend
 
 ## Install
 
@@ -21,4 +26,6 @@ const app = createApp({
 export default app.createRoot();
 ```
 
-See the repository root documentation for complete setup, including the backend plugin and auth handler module.
+This package registers the UI. It does not provide the backend API on its own.
+
+For the full installation flow, configuration, and permission policy wiring, see the root [README](../../README.md) and [Getting Started guide](../../docs/getting-started.md).


### PR DESCRIPTION
## Summary
- rewrite the root README as a clearer public landing page for Backstage adopters
- reorganize the docs site by audience and surface reference and maintainer docs in MkDocs navigation
- strengthen package READMEs and clean up maintainer-specific details in public docs
- fix broken internal MkDocs links found during validation

## Contract changes
- none

## Verification
- npm run docs:install
- .venv/bin/mkdocs build

## Notes
- npm run docs:serve built successfully but could not bind a local port inside the sandbox, so the final validation used mkdocs build instead