### PR TITLE
docs: add branch workflow guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,11 +45,19 @@ Treat these as locked unless the public contract is intentionally changed across
 - Update docs and tests together when behavior, contract, or workflow changes
 - Keep documentation current whenever code, APIs, configuration, or maintainer workflow changes
 - Write `README.md` and general user-facing documentation with the standards of an experienced open source technical writer for Backstage-style projects: clear audience-aware structure, practical examples, accurate installation and usage guidance, and concise explanations that help new adopters succeed quickly
+- For any documentation task, act as a senior open source technical writer for successful GitHub projects: write for the real audience first, optimize for time-to-success, verify claims against code/tests/commands, prefer practical examples over abstract explanation, and keep onboarding, reference, and maintainer workflow docs aligned
 - Add or update JSDoc where exported behavior, interfaces, or non-obvious logic need durable explanation
 - Keep commits reviewable and grouped by change type
 - Use Conventional Commits
 - Do not casually rewrite `docs/contract-decisions.md`; only change it when the intended public contract changes
 - When creating plans, prefer iterative and incremental steps that establish truth before building on later work
+
+## Branch Naming
+
+- For this repository, agents should use the same branch naming pattern documented in `docs/git-workflow.md`: `<type>/<short-topic>`
+- Do not prepend tool-specific prefixes such as `codex/` to agent-created branches in this repository
+- Match branch topics to one reviewable change, for example `docs/fix-api-reference` or `fix/revoke-ttl-docs`
+- If the user provides a branch name, follow the user's choice
 
 ## Validation Expectations
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,7 @@ npm run pack:dry-run
 ## Contribution standards
 
 - Follow Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`...)
+- Use branch names that follow the repository Git workflow pattern: `<type>/<short-topic>`
 - Keep PRs small and focused
 - Add/adjust tests for behavior changes
 - Update docs whenever behavior, API, or config changes

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Start here based on what you are trying to do:
 | [Architecture](docs/architecture.md) | Contributor | Internal design and package responsibilities |
 | [Contract Decisions](docs/contract-decisions.md) | Contributor or reviewer | Canonical public behavior that should stay stable |
 | [Developer Test Guide](docs/developer-test-guide.md) | Maintainer | Fast repeatable verification for unpublished changes |
+| [Git Workflow](docs/git-workflow.md) | Maintainer or contributor | Branching and pull request conventions for this repository |
 | [Release Guide](docs/releasing.md) | Maintainer | Changesets and npm publishing workflow |
 
 ## Package READMEs

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -1,0 +1,60 @@
+# Git Workflow
+
+Audience: maintainers and contributors making changes in this repository.
+
+Use GitHub Flow for day-to-day work in this project. Keep it lightweight, keep `main` releasable, and use pull requests to review contract, docs, and test impact before merge.
+
+## Branching
+
+Create each branch from `main`.
+
+Use this naming pattern:
+
+```text
+<type>/<short-topic>
+```
+
+Examples:
+
+- `feat/add-token-audit-filter`
+- `fix/revoke-cache-ttl-docs`
+- `docs/update-install-example`
+- `test/api-smoke-harness`
+- `chore/bump-backstage-deps`
+
+Choose short, readable topics that describe one reviewable change.
+
+Automated agents should follow the same pattern and should not prepend tool-specific prefixes such as `codex/`.
+
+## Recommended Loop
+
+1. Update your local `main`.
+2. Create a branch for one change.
+3. Make the smallest reviewable set of edits that keeps code, docs, and tests aligned.
+4. Run the relevant validation commands before opening or updating the pull request.
+5. Open a pull request against `main`.
+6. Merge after review and successful validation.
+
+## Pull Request Expectations
+
+Keep pull requests focused and easy to review:
+
+- use Conventional Commits for local commit history
+- summarize any contract change explicitly
+- list the verification commands you actually ran
+- update docs when behavior, workflow, or configuration changed
+- avoid mixing unrelated fixes into the same branch
+
+If a change touches auth, permissions, audit fields, revoke behavior, or installation wiring, verify the implementation still matches the canonical docs:
+
+- [README](../README.md)
+- [Contract Decisions](contract-decisions.md)
+- [REST API Reference](api.md)
+- [Testing Guide](testing.md)
+- [Developer Test Guide](developer-test-guide.md)
+
+## Keeping Branches Current
+
+If `main` moves while your branch is open, update your branch before merge so final review reflects current behavior.
+
+Prefer a clean history and avoid long-lived branches when possible. Small branches reduce drift and make contract review easier.

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,7 @@ Choose the path that matches your job:
 ## Maintainers
 
 - [Developer Test Guide](developer-test-guide.md)
+- [Git Workflow](git-workflow.md)
 - [Release Guide](releasing.md)
 
-These docs are intentionally maintainer-oriented. They cover unpublished package testing, local file-based verification, and npm release workflow rather than the adopter install story.
+These docs are intentionally maintainer-oriented. They cover unpublished package testing, local file-based verification, branch and pull request conventions, and npm release workflow rather than the adopter install story.


### PR DESCRIPTION
## Summary
- add repository-specific agent guidance that branches should use `<type>/<short-topic>`
- document that automated agents should not prepend tool-specific prefixes such as `codex/`
- link the Git workflow guide from the maintainer-facing docs index and README

## Contract Changes
- none

## Verification
- reviewed updated docs for consistency across `AGENTS.md`, `docs/git-workflow.md`, `CONTRIBUTING.md`, `README.md`, and `docs/index.md`
- no tests run (docs-only change, no runtime behavior changed)