### PR TITLE
docs: refresh package README onboarding

### DIFF
--- a/.changeset/green-bears-taste.md
+++ b/.changeset/green-bears-taste.md
@@ -1,0 +1,8 @@
+---
+'@adriandantas/plugin-service-tokens-backend': patch
+'@adriandantas/plugin-service-tokens-node': patch
+'@adriandantas/plugin-service-tokens': patch
+---
+
+Refresh package README guidance for npm consumers with clearer install context,
+minimum setup examples, and package-specific export notes.

--- a/packages/plugin-service-tokens-backend/README.md
+++ b/packages/plugin-service-tokens-backend/README.md
@@ -1,32 +1,84 @@
 # @adriandantas/plugin-service-tokens-backend
 
-Backend Backstage plugin for creating, listing, auditing, and revoking service tokens.
+Backstage backend plugin for the service token lifecycle API.
 
-This package provides:
+This package provides the `/api/service-tokens` REST API, token persistence and migrations, scope catalogue assembly, and permission-gated create, read, audit, and revoke routes.
 
-- the `/api/service-tokens` REST API
-- database persistence and migrations
-- permission checks for read, write, and revoke operations
+## When To Use This Package
 
-It should be installed together with `@adriandantas/plugin-service-tokens-node`, which supplies the external auth handler module used to validate raw service tokens.
+Install this package when you want your Backstage backend to issue and manage long-lived, group-scoped service tokens.
+
+Use it together with:
+
+- `@adriandantas/plugin-service-tokens-node` to register the raw token auth handler and import service token permissions into your policy
+- `@adriandantas/plugin-service-tokens` if you also want the admin UI at `/admin/service-tokens`
 
 ## Install
+
+Add the backend plugin and its required node companion package to your Backstage backend workspace:
 
 ```bash
 yarn --cwd packages/backend add @adriandantas/plugin-service-tokens-backend
 yarn --cwd packages/backend add @adriandantas/plugin-service-tokens-node
 ```
 
-## Usage
+## Minimum Working Setup
+
+Register both the backend plugin and the auth handler module in your backend entry point:
 
 ```ts
+// packages/backend/src/index.ts
+import { createBackend } from '@backstage/backend-defaults';
 import { serviceTokensPlugin } from '@adriandantas/plugin-service-tokens-backend';
 import { serviceTokenHandlerModule } from '@adriandantas/plugin-service-tokens-node';
 
+const backend = createBackend();
+
 backend.add(serviceTokensPlugin);
 backend.add(serviceTokenHandlerModule);
+
+backend.start();
 ```
 
-This package expects the Backstage permission framework to be installed and a permission policy to grant `service-tokens:read`, `service-tokens:write`, and `service-tokens:revoke`.
+Why both registrations matter:
 
-For the full installation flow, policy wiring, and config reference, see the root [README](../../README.md) and [Getting Started guide](../../docs/getting-started.md).
+- `serviceTokensPlugin` serves the `/api/service-tokens` routes and manages storage
+- `serviceTokenHandlerModule` makes raw service tokens authenticate successfully through Backstage's auth layer
+
+## Permissions
+
+This package expects the Backstage permission framework to be installed and your permission policy to grant the service token routes explicitly:
+
+- `service-tokens:read`
+- `service-tokens:write`
+- `service-tokens:revoke`
+
+Those permission definitions are exported by `@adriandantas/plugin-service-tokens-node`.
+
+## Main Export
+
+The primary integration export is:
+
+- `serviceTokensPlugin` and the default export: the backend feature you add with `backend.add(...)`
+
+This package also exports lower-level helpers for advanced or test-oriented use cases, including:
+
+- `createExpressRouter` and `createHttpApi` for custom mounting
+- `createKnexServiceTokenDatabase` and `createInMemoryServiceTokenDatabase` for storage integration and tests
+- `applyServiceTokenMigrations` for direct migration control
+- `defaultScopes` and `getScopeCatalogue` for scope catalogue composition
+
+Most adopters should start with `serviceTokensPlugin` and only reach for the lower-level exports when they need custom backend wiring.
+
+## What This Package Does Not Include
+
+This package does not register the external auth handler by itself, which is why `@adriandantas/plugin-service-tokens-node` is required.
+
+It also does not provide the frontend admin page. If you want the UI, install `@adriandantas/plugin-service-tokens` in your Backstage app package.
+
+## Learn More
+
+- [Root README](../../README.md) for the installation overview
+- [Getting Started](../../docs/getting-started.md) for the supported integration flow
+- [REST API Reference](../../docs/api.md) for route contracts and response shapes
+- [Testing Guide](../../docs/testing.md) for post-install validation

--- a/packages/plugin-service-tokens-node/README.md
+++ b/packages/plugin-service-tokens-node/README.md
@@ -1,29 +1,79 @@
 # @adriandantas/plugin-service-tokens-node
 
-Shared Backstage node library for the service token auth handler, permission exports, and verification utilities.
+Shared Backstage node library for service token auth and permission wiring.
 
-This package is primarily used by the backend plugin, but it also exposes the pieces you need when wiring auth and permission policies.
+This package is the backend-facing companion to the service token plugin. Most adopters use it to register the external auth handler that accepts raw service tokens and to import the permission definitions used by a Backstage permission policy.
+
+## When To Use This Package
+
+Install this package when you need either of these integration points:
+
+- register `serviceTokenHandlerModule` in your backend so raw service tokens are accepted by Backstage auth
+- import the service token permission definitions into your permission policy
+
+You will typically install it together with `@adriandantas/plugin-service-tokens-backend`.
 
 ## Install
+
+Add the package to your Backstage backend workspace:
 
 ```bash
 yarn --cwd packages/backend add @adriandantas/plugin-service-tokens-node
 ```
 
-## Usage
+## Minimum Working Setup
 
 Register the auth handler module in your backend:
 
 ```ts
+// packages/backend/src/index.ts
+import { createBackend } from '@backstage/backend-defaults';
 import { serviceTokenHandlerModule } from '@adriandantas/plugin-service-tokens-node';
+
+const backend = createBackend();
 
 backend.add(serviceTokenHandlerModule);
 ```
 
-This package also exports the service token permission definitions used in permission policies:
+In the normal plugin installation flow you register this module alongside `serviceTokensPlugin` from `@adriandantas/plugin-service-tokens-backend`.
+
+## Permission Exports
+
+Use these permission definitions in your Backstage permission policy:
 
 - `serviceTokensReadPermission`
 - `serviceTokensWritePermission`
 - `serviceTokensRevokePermission`
 
-For the complete installation flow and backend integration guidance, see the root [README](../../README.md) and [Getting Started guide](../../docs/getting-started.md).
+This package also exports:
+
+- `serviceTokensAdminPermission` as a deprecated compatibility alias that maps to read-only behavior
+
+New policies should use the granular read, write, and revoke permissions directly.
+
+## Main Public Exports
+
+The primary externally useful exports are:
+
+- `serviceTokenHandlerModule`
+- `serviceTokensReadPermission`
+- `serviceTokensWritePermission`
+- `serviceTokensRevokePermission`
+- `serviceTokensPermissions`
+
+This package also exposes lower-level helpers such as `verifyToken`, `createTokenCache`, `createServiceTokenAuthDatabase`, `createServiceTokenHandler`, and `createScopeResolver`.
+
+Those helpers are useful for advanced integration and testing, but most adopters should not need them for the default install path.
+
+## What This Package Does Not Include
+
+This package does not provide the REST API routes or persistence plugin entry point by itself. For that, install `@adriandantas/plugin-service-tokens-backend`.
+
+It also does not provide the admin UI. For that, install `@adriandantas/plugin-service-tokens` in your Backstage app package.
+
+## Learn More
+
+- [Root README](../../README.md) for the full package overview
+- [Getting Started](../../docs/getting-started.md) for backend and policy wiring
+- [REST API Reference](../../docs/api.md) for the backend contract this module supports
+- [Testing Guide](../../docs/testing.md) for post-install validation

--- a/packages/plugin-service-tokens/README.md
+++ b/packages/plugin-service-tokens/README.md
@@ -1,31 +1,72 @@
 # @adriandantas/plugin-service-tokens
 
-Frontend Backstage plugin that adds the service token admin page at `/admin/service-tokens`.
+Backstage frontend plugin for the service token admin page.
 
-Use this package together with:
+This package adds the `/admin/service-tokens` UI for creating, listing, auditing, and revoking service tokens. It registers the page in the new frontend system, but it does not provide the backend API or raw token auth handling on its own.
 
-- `@adriandantas/plugin-service-tokens-backend` for the REST API and persistence
-- `@adriandantas/plugin-service-tokens-node` for the auth handler module used by the backend
+## When To Use This Package
+
+Install this package when you want the service token admin UI in your Backstage app.
+
+Use it together with:
+
+- `@adriandantas/plugin-service-tokens-backend` for the `/api/service-tokens` backend API and persistence
+- `@adriandantas/plugin-service-tokens-node` for the backend auth handler and permission exports
 
 ## Install
+
+Add the frontend plugin to your Backstage app workspace:
 
 ```bash
 yarn --cwd packages/app add @adriandantas/plugin-service-tokens
 ```
 
-## Usage
+## Minimum Working Setup
+
+Register the frontend feature with `createApp({ features: [...] })`:
 
 ```ts
+// packages/app/src/App.tsx
 import { createApp } from '@backstage/frontend-defaults';
 import serviceTokensPlugin from '@adriandantas/plugin-service-tokens';
 
 const app = createApp({
-  features: [serviceTokensPlugin],
+  features: [
+    serviceTokensPlugin,
+  ],
 });
 
 export default app.createRoot();
 ```
 
-This package registers the UI. It does not provide the backend API on its own.
+The page is registered at `/admin/service-tokens`. No extra route wiring is required in the default frontend setup.
+If you prefer named imports, `serviceTokensPlugin` is also exported by name.
 
-For the full installation flow, configuration, and permission policy wiring, see the root [README](../../README.md) and [Getting Started guide](../../docs/getting-started.md).
+## Main Export
+
+This package exports the frontend feature as:
+
+- the default export
+- `serviceTokensPlugin`
+
+It also exports `rootRouteRef` for apps that need access to the route reference.
+
+## What This Package Does Not Include
+
+This package only provides the UI layer.
+
+It does not:
+
+- serve the `/api/service-tokens` endpoints
+- store tokens
+- verify raw service tokens in the backend auth layer
+- grant permissions by itself
+
+To make the page functional, wire the backend and node packages into your Backstage backend and add a permission policy that grants `service-tokens:read`, `service-tokens:write`, and `service-tokens:revoke` where appropriate.
+
+## Learn More
+
+- [Root README](../../README.md) for the package overview and install order
+- [Getting Started](../../docs/getting-started.md) for full frontend and backend wiring
+- [REST API Reference](../../docs/api.md) for the backend contract this UI consumes
+- [Testing Guide](../../docs/testing.md) for post-install validation


### PR DESCRIPTION
## Summary
- refresh the package READMEs so each works better as a standalone npm package page
- clarify package purpose, install context, minimum setup, and intended exports
- improve links back to the canonical root docs and guides

## Contract changes
- none

## Verification
- npm test

Closes #8