### PR TITLE
chore(license): migrate project to Apache-2.0

### DIFF
--- a/.changeset/chilly-bugs-glow.md
+++ b/.changeset/chilly-bugs-glow.md
@@ -1,0 +1,7 @@
+---
+'@adriandantas/plugin-service-tokens-backend': patch
+'@adriandantas/plugin-service-tokens-node': patch
+'@adriandantas/plugin-service-tokens': patch
+---
+
+Migrate package licensing metadata from BUSL-1.1 to Apache-2.0 and align repository license documentation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- License migrated from Business Source License 1.1 (BUSL-1.1) to Apache License 2.0 (Apache-2.0).
 - Token-management routes now authorize per action instead of using a single admin permission.
 - Documentation and examples now describe the granular permission model throughout the project.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,60 +1,178 @@
-Business Source License 1.1
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Parameters
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Licensor:             Adrian Dantas
-Licensed Work:        backstage-service-token-plugin
-Additional Use Grant: You may copy, modify, create derivative works of, and
-                      self-host this software for internal business purposes
-                      at no charge. You may not provide this software (or a
-                      substantially similar hosted offering) to third parties
-                      as a managed/hosted service without a separate
-                      commercial license from the Licensor.
-Change Date:          2029-04-05
-Change License:       Apache License, Version 2.0
+   1. Definitions.
 
-Terms
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-Business Source License 1.1
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-Copyright (C) 2026 Adrian Dantas
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-Everyone is granted the right to copy, modify, create derivative works, and
-redistribute the Licensed Work, subject to the terms of this License.
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
 
-The Licensor hereby grants you the right to copy, modify, create derivative
-works, publicly display, publicly perform, sublicense, and distribute the
-Licensed Work and such derivative works for any purpose, provided that any use
-of the Licensed Work in violation of this License will automatically terminate
-your rights under this License for the current and all other versions of the
-Licensed Work.
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
 
-Use Limitation. The right to use the Licensed Work for any purpose is granted
-only to the extent such use does not violate the Additional Use Grant.
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
 
-The Licensor may make new versions of the Licensed Work available under this
-License from time to time. As of the Change Date, all use of the Licensed Work
-and derivative works is governed by the Change License.
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
 
-If your use of the Licensed Work does not violate the Additional Use Grant,
-then this License grants you rights substantially similar to those granted
-under the Apache License, Version 2.0.
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
 
-If your use of the Licensed Work does violate the Additional Use Grant, then
-you must obtain a commercial license from the Licensor.
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
 
-This License does not grant any rights to use the Licensor's trademarks,
-service marks, or logos.
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
 
-TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS
-PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
-INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE LICENSOR BE
-LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN ACTION OF
-CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR IN CONNECTION WITH THE
-LICENSED WORK OR THE USE OR OTHER DEALINGS IN THE LICENSED WORK.
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
 
----
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
 
-This file is based on the BUSL-1.1 form published at:
-https://mariadb.com/bsl11/
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Adrian Dantas

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Node 22](https://img.shields.io/badge/node-22-brightgreen)](https://nodejs.org/)
 [![Backstage](https://img.shields.io/badge/backstage-compatible-blue)](https://backstage.io/)
 [![Packages](https://img.shields.io/badge/packages-3-informational)](#packages)
-[![License: BUSL-1.1](https://img.shields.io/badge/license-BUSL--1.1-yellow)](LICENSE)
+[![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 
 ## What This Plugin Does
 
@@ -235,8 +235,6 @@ If you are iterating on unpublished package changes, use the maintainer-focused 
 
 ## License
 
-Business Source License 1.1 (BUSL-1.1).
-
-Free for internal self-hosted use. Hosting this plugin, or a substantially similar managed service, for third parties requires a commercial license from the licensor.
+Apache License 2.0 (Apache-2.0).
 
 See [LICENSE](LICENSE) for full terms.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "backstage-service-token-plugin",
   "version": "0.0.0",
   "private": true,
-  "license": "BUSL-1.1",
+  "license": "Apache-2.0",
   "type": "module",
   "scripts": {
     "changeset": "changeset",

--- a/packages/plugin-service-tokens-backend/package.json
+++ b/packages/plugin-service-tokens-backend/package.json
@@ -2,7 +2,7 @@
   "name": "@adriandantas/plugin-service-tokens-backend",
   "version": "0.1.0",
   "description": "Backstage backend plugin for service token lifecycle management and REST APIs.",
-  "license": "BUSL-1.1",
+  "license": "Apache-2.0",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "service-tokens",

--- a/packages/plugin-service-tokens-node/package.json
+++ b/packages/plugin-service-tokens-node/package.json
@@ -2,7 +2,7 @@
   "name": "@adriandantas/plugin-service-tokens-node",
   "version": "0.1.0",
   "description": "Backstage node library and external auth handler module for service token verification.",
-  "license": "BUSL-1.1",
+  "license": "Apache-2.0",
   "backstage": {
     "role": "node-library"
   },

--- a/packages/plugin-service-tokens/package.json
+++ b/packages/plugin-service-tokens/package.json
@@ -2,7 +2,7 @@
   "name": "@adriandantas/plugin-service-tokens",
   "version": "0.1.0",
   "description": "Backstage frontend plugin for creating, listing, auditing, and revoking service tokens.",
-  "license": "BUSL-1.1",
+  "license": "Apache-2.0",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "service-tokens",


### PR DESCRIPTION
## Summary
- replace BUSL-1.1 license terms with Apache-2.0 in root LICENSE
- update workspace package SPDX metadata to Apache-2.0
- align README badge/license section and changelog unreleased note

## Verification
- npm test
- rg -n "BUSL|Business Source|commercial license" README.md CHANGELOG.md package.json packages LICENSE -S
- rg -n "\"license\": \"Apache-2.0\"" package.json packages/*/package.json -S

Closes #24