### PR TITLE
ci: update artifact uploads to Node 24 action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Upload verification log on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: verify-log
           path: verify.log
@@ -90,7 +90,7 @@ jobs:
 
       - name: Upload UI smoke artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ui-smoke-artifacts
           path: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Upload verification log on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: publish-verify-log
           path: verify.log

--- a/.github/workflows/ui-smoke.yml
+++ b/.github/workflows/ui-smoke.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Upload Playwright artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ui-smoke-artifacts
           path: |


### PR DESCRIPTION
## Summary
- update all upload-artifact workflow steps from v4 to v7
- keep existing artifact names, paths, and missing-file behavior unchanged
- remove the Node 20 deprecation annotation by using the upstream Node 24 action runtime

## Contract changes
- none

## Verification
- rg "actions/upload-artifact@v4" .github -n
- rg "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24|ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION" .github -n
- git diff --check
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/ci.yml .github/workflows/ui-smoke.yml .github/workflows/publish.yml