### PR TITLE
fix(ci): allow workflow_dispatch to pass release-guard job condition

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   release-guard:
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     outputs:
       should_publish: ${{ steps.guard.outputs.should_publish }}


### PR DESCRIPTION
## Summary

- The `release-guard` job had `if: github.event.pull_request.merged == true` at the job level, which caused all jobs to be skipped for `workflow_dispatch` events — the dispatch handling added in PR #35 was inside the step and never reached
- Adds `|| github.event_name == 'workflow_dispatch'` to the job condition so manual dispatches flow through the guard correctly

## Test plan

- [ ] Merge this PR
- [ ] Trigger `workflow_dispatch` via `gh workflow run publish.yml --ref main`
- [ ] Confirm `release-guard`, `verify`, and `publish` jobs all run (not skipped)
- [ ] Confirm packages appear on npmjs.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)