### PR TITLE
ci: switch npm publish to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,9 +90,6 @@ jobs:
     needs: [release-guard, verify]
     if: needs.release-guard.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
-    env:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     steps:
       - name: Checkout merged release commit
@@ -111,25 +108,14 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
-      - name: Skip publish when NPM_TOKEN is not configured
-        if: env.NPM_TOKEN == ''
-        run: echo "NPM_TOKEN is not configured; skipping npm publish."
-
-      - name: Verify npm authentication
-        if: env.NPM_TOKEN != ''
-        run: npm whoami --registry=https://registry.npmjs.org
-
       - name: Publish changed packages to npm
-        if: env.NPM_TOKEN != ''
         id: changesets
         uses: changesets/action@v1
         with:
           publish: npx changeset publish --provenance
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ env.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ env.NODE_AUTH_TOKEN }}
 
       - name: Push release tags
-        if: env.NPM_TOKEN != '' && steps.changesets.outputs.published == 'true'
+        if: steps.changesets.outputs.published == 'true'
         run: git push origin --tags


### PR DESCRIPTION
## Summary

- Removes `NPM_TOKEN` dependency from the publish workflow
- Packages now authenticate via OIDC through npm Trusted Publishing (configured on each of the three `@primedx` packages on npmjs.com)
- Drops the token-guard conditions, `npm whoami` step, and `Skip publish` step — publish always runs when `should_publish == true`
- Keeps `--provenance` flag, which npm uses to obtain the OIDC token

## Test plan

- [ ] Merge this PR
- [ ] On the next release PR merge (or `workflow_dispatch`), confirm the publish job succeeds without `NPM_TOKEN` configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)