### PR TITLE
ci(release): use GitHub App token for changesets release PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js 22
         uses: actions/setup-node@v6
@@ -38,4 +46,4 @@ jobs:
           title: Version Packages
           commit: "chore(release): version packages"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Problem

The **Release PR** workflow fails at the changesets step with:

> HttpError: GitHub Actions is not permitted to create or approve pull requests.

(See run [27617783249](https://github.com/PrimeDX/backstage-access-tokens-plugin/actions/runs/27617783249/job/81658028823).)

The org forbids GitHub Actions from creating/approving pull requests, and this policy overrides the repo-level setting — so the default `GITHUB_TOKEN` cannot open the version PR.

## Fix

Mint a short-lived GitHub App installation token with `actions/create-github-app-token` and use it for both `checkout` and `changesets/action`. The version PR is then created as the App identity, which bypasses the org policy. As a bonus, commits pushed with an App token (unlike `GITHUB_TOKEN`) trigger downstream workflows such as `ci.yml`.

## Required setup (already done)

A PrimeDX-owned GitHub App is installed on this repo with **Contents: Read & write** and **Pull requests: Read & write**, and two repository secrets are configured:

- `RELEASE_APP_ID`
- `RELEASE_APP_PRIVATE_KEY`