### PR TITLE
ci(release): refresh e2e harness lockfile during version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Open or update version PR
         uses: changesets/action@v1
         with:
-          version: npx changeset version
+          version: npm run version:ci
           title: Version Packages
           commit: "chore(release): version packages"
         env:

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "changeset": "changeset",
+    "version:ci": "changeset version && cd e2e/harness && yarn install --mode update-lockfile",
     "docs:install": "python3 -m venv .venv && .venv/bin/pip install mkdocs mkdocs-material",
     "docs:serve": ".venv/bin/mkdocs serve",
     "harness:install": "yarn --cwd e2e/harness install",


### PR DESCRIPTION
## Problem

With the App-token fix from #40, the **Release PR** workflow now successfully opens the version PR. But that PR's CI fails in the `ui-smoke` job at *Install harness dependencies*:

> YN0028: The lockfile would have been modified by this install, which is explicitly forbidden.

(See run [27629763888](https://github.com/PrimeDX/backstage-access-tokens-plugin/actions/runs/27629763888/job/81701736846).)

### Root cause

`e2e/harness/yarn.lock` pins Yarn `file:` **content hashes** for the local packages:

```
@primedx/plugin-access-tokens#...::hash=d9e866
@primedx/plugin-access-tokens-backend#...::hash=22af8d
@primedx/plugin-access-tokens-node#...::hash=070df9
```

`changeset version` bumps those packages' versions, which changes the content hashes. The committed harness lockfile is now stale, so `yarn install --immutable` rejects it. This isn't just a CI nuisance — once the version PR merges, **main itself is left inconsistent** (bumped `package.json` vs. old lockfile hashes).

## Fix

Add a `version:ci` script that, after `changeset version`, refreshes the harness lockfile:

```
changeset version && cd e2e/harness && yarn install --mode update-lockfile
```

`--mode update-lockfile` rewrites the hashes without a full fetch/link step. `changesets/action` then commits the updated `e2e/harness/yarn.lock` into the version PR, so `--immutable` passes in CI and main stays consistent after merge.

## Validation

Locally bumped `plugin-access-tokens` to a throwaway version and ran the harness `update-lockfile` — the hash re-stamped (`d9e866` → `78410e`) with the link step skipped and only benign peer-dependency warnings. Reverted afterward.

## Effect on the open version PR

Merging this re-triggers the release workflow on `main`, which updates the existing `changeset-release/main` PR with the refreshed lockfile; its `ui-smoke` job should then pass.