### PR TITLE
ci(publish): upgrade npm to 11.x for OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -105,6 +105,9 @@ jobs:
           cache: yarn
           registry-url: https://registry.npmjs.org
 
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@11
+
       - name: Install dependencies
         run: yarn install --immutable
 


### PR DESCRIPTION
## Problem

The `Publish` workflow fails at `changeset publish` with:

> npm error 404 '@primedx/plugin-access-tokens@0.2.1' is not in this registry.

(See run [27631597540](https://github.com/PrimeDX/backstage-access-tokens-plugin/actions/runs/27631597540/job/81709029062).)

The package already exists at `0.2.0`, so the `E404` on publishing `0.2.1` is npm's way of reporting an **unauthorized** publish (it returns 404 rather than 403 for existing packages).

### Root cause

Publishing uses **OIDC trusted publishing** (no `NPM_TOKEN` in the job env). The trusted publisher *is* correctly configured on each `@primedx` package (org `PrimeDX`, repo `backstage-access-tokens-plugin`, workflow `publish.yml`, action `npm publish`).

The missing piece is the runner's npm version: trusted publishing requires **npm >= 11.5.1**, but Node 22 ships **npm 10.x**. With npm 10.x the OIDC token exchange never happens, so the publish runs unauthenticated and is rejected.

> "Trusted publishing requires npm CLI version 11.5.1 or later and Node version 22.14.0 or higher." — [npm docs](https://docs.npmjs.com/trusted-publishers)

## Fix

Install `npm@11` in the publish job before publishing, so `changeset publish --provenance` runs on an npm that can perform the OIDC token exchange.

## After merge

`0.2.1` is already staged on `main` and unpublished. Re-run publishing via dispatch (the workflow's `workflow_dispatch` path is allow-listed by `release-guard`):

```
gh workflow run publish.yml --repo PrimeDX/backstage-access-tokens-plugin
```