### PR TITLE
docs(agents): document harness lockfile CI rule; add harness:lockfile script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,21 @@ Use a local Backstage integration harness for end-to-end validation. For recomme
 
 The harness consumes this repo's packages through Yarn `file:` dependencies, which are copied into `e2e/harness/node_modules/@primedx/*` rather than live-symlinked. After changing any `packages/plugin-access-tokens*` package, run `yarn install` from `e2e/harness` before starting the harness or running harness-based validation. This refreshes the copied package snapshots and the harness lockfile hash so manual testing and Playwright/API smoke tests exercise the current source.
 
+### CI impact: you must commit the refreshed harness lockfile
+
+Because the harness depends on the local packages via Yarn `file:` references, `e2e/harness/yarn.lock` pins a **content hash** of each `@primedx/*` package. Any change to a `packages/plugin-access-tokens*` `package.json` or to a published file (anything in that package's `files` list) changes that hash.
+
+The `ui-smoke` CI job runs `yarn install --immutable` in `e2e/harness`, so a stale harness lockfile fails the build with `YN0028: The lockfile would have been modified by this install, which is explicitly forbidden.`
+
+Therefore, in the **same PR** as any such package change, regenerate and commit the harness lockfile:
+
+```bash
+npm run harness:lockfile   # cd e2e/harness && yarn install --mode update-lockfile
+git add e2e/harness/yarn.lock
+```
+
+This is the single most common cause of an otherwise-green PR failing `ui-smoke`. Note: the release `version:ci` script already runs this automatically during `changeset version`, so the auto-generated `Version Packages` PR does not need manual lockfile updates — but direct edits to package files do.
+
 If a change is not meaningfully tested, call that out explicitly rather than implying confidence.
 
 ## Pull Requests

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "docs:install": "python3 -m venv .venv && .venv/bin/pip install mkdocs mkdocs-material",
     "docs:serve": ".venv/bin/mkdocs serve",
     "harness:install": "yarn --cwd e2e/harness install",
+    "harness:lockfile": "cd e2e/harness && yarn install --mode update-lockfile",
     "harness:start": "yarn --cwd e2e/harness start",
     "ci": "npm run test && npm run storybook:build && npm run pack:dry-run",
     "pack:backend": "npm_config_cache=/tmp/npm-cache npm pack --dry-run --workspace packages/plugin-access-tokens-backend",


### PR DESCRIPTION
## Why

Editing any `packages/plugin-access-tokens*` `package.json` or published file changes the Yarn `file:` content hash that `e2e/harness/yarn.lock` pins. The `ui-smoke` job runs `yarn install --immutable` in `e2e/harness`, so a stale harness lockfile fails with:

> YN0028: The lockfile would have been modified by this install, which is explicitly forbidden.

This has tripped up multiple PRs (e.g. the `repository` metadata change). AGENTS.md mentioned refreshing the harness for *local testing* but never framed it as a hard CI requirement to commit the lockfile.

## Changes

- **AGENTS.md** — new "CI impact: you must commit the refreshed harness lockfile" subsection explaining the cause and the required step, and noting that `version:ci` already handles the version-bump case automatically.
- **package.json** — add `harness:lockfile` script: `cd e2e/harness && yarn install --mode update-lockfile`, so the required step is one command (`npm run harness:lockfile`).

No package or published-file changes, so no changeset and no harness lockfile update needed here.